### PR TITLE
4: HTML Templates

### DIFF
--- a/assets/assets.go
+++ b/assets/assets.go
@@ -1,0 +1,6 @@
+package assets
+
+import "embed"
+
+//go:embed templates/*
+var TemplateFS embed.FS

--- a/assets/templates/base.html
+++ b/assets/templates/base.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>{{ template "title" .}}</title>
+</head>
+<body>
+  {{ template "body" . }}
+</body>
+</html>

--- a/assets/templates/hello-world.html
+++ b/assets/templates/hello-world.html
@@ -1,0 +1,5 @@
+{{ define "title" }}{{ . }}{{end}}
+
+{{define "body"}}
+<h1>{{ . }}</h1>
+{{end}}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -9,6 +9,9 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/willemschots/househunt/assets"
+	"github.com/willemschots/househunt/internal/web"
+	"github.com/willemschots/househunt/internal/web/view"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -28,18 +31,14 @@ func run(ctx context.Context, w io.Writer) int {
 		return 1
 	}
 
+	viewRenderer := view.NewFSRenderer(assets.TemplateFS)
+
 	srv := &http.Server{
 		Addr:         cfg.http.addr,
 		ReadTimeout:  cfg.http.readTimeout,
 		WriteTimeout: cfg.http.writeTimeout,
 		IdleTimeout:  cfg.http.idleTimeout,
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-			_, err := w.Write([]byte("Hello, world!"))
-			if err != nil {
-				logger.Error("failed to write response", "error", err)
-			}
-		}),
+		Handler:      web.NewServer(logger, viewRenderer),
 	}
 
 	// We need to run two tasks concurrently:

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -1,0 +1,38 @@
+package web
+
+import (
+	"io"
+	"log"
+	"log/slog"
+	"net/http"
+)
+
+type ViewRenderer interface {
+	Render(w io.Writer, name string, data any) error
+}
+
+type Server struct {
+	mux          *http.ServeMux
+	logger       *log.Logger
+	ViewRenderer ViewRenderer
+}
+
+func NewServer(logger *slog.Logger, viewRenderer ViewRenderer) *Server {
+	mux := http.NewServeMux()
+
+	mux.Handle("GET /", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		err := viewRenderer.Render(w, "hello-world", "Hello World! (via a template)")
+		if err != nil {
+			logger.Error("error rendering view", "error", err)
+		}
+	}))
+
+	return &Server{
+		mux: mux,
+	}
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.mux.ServeHTTP(w, r)
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -2,7 +2,6 @@ package web
 
 import (
 	"io"
-	"log"
 	"log/slog"
 	"net/http"
 )
@@ -11,13 +10,7 @@ type ViewRenderer interface {
 	Render(w io.Writer, name string, data any) error
 }
 
-type Server struct {
-	mux          *http.ServeMux
-	logger       *log.Logger
-	ViewRenderer ViewRenderer
-}
-
-func NewServer(logger *slog.Logger, viewRenderer ViewRenderer) *Server {
+func NewServer(logger *slog.Logger, viewRenderer ViewRenderer) http.Handler {
 	mux := http.NewServeMux()
 
 	mux.Handle("GET /", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -28,11 +21,5 @@ func NewServer(logger *slog.Logger, viewRenderer ViewRenderer) *Server {
 		}
 	}))
 
-	return &Server{
-		mux: mux,
-	}
-}
-
-func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	s.mux.ServeHTTP(w, r)
+	return mux
 }

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1,0 +1,1 @@
+package web_test

--- a/internal/web/view/fs_renderer.go
+++ b/internal/web/view/fs_renderer.go
@@ -1,0 +1,25 @@
+package view
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+)
+
+// FSRenderer renders views from a file system.
+type FSRenderer struct {
+	fs fs.FS
+}
+
+// NewFSRenderer returns a new FSRenderer.
+func NewFSRenderer(fs fs.FS) *FSRenderer {
+	return &FSRenderer{fs: fs}
+}
+
+func (r *FSRenderer) Render(w io.Writer, name string, data any) error {
+	v, err := Parse(r.fs, name)
+	if err != nil {
+		return fmt.Errorf("failed to parse view: %w", err)
+	}
+	return v.Render(w, data)
+}

--- a/internal/web/view/view.go
+++ b/internal/web/view/view.go
@@ -1,0 +1,89 @@
+package view
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"text/template"
+)
+
+const baseFilename = "base.html"
+
+// View is a collection of templates used to render data. Every
+// view has an unique name.
+//
+// A view combines the following templates to render a HTML page:
+// - base.html (required)
+// - {name}.html (optional)
+// - partials/*.html (optional)
+type View struct {
+	name     string
+	template *template.Template
+}
+
+// Parse parses the file system and returns a view for the given name.
+func Parse(viewFS fs.FS, name string) (*View, error) {
+	// Validate the filename, just to be sure.
+	//
+	// Generally these will be hardcoded, but if for some reason we end
+	// up with user input as a filename, we don't want to allow them
+	// access to the filesystem.
+	if err := validateName(name); err != nil {
+		return nil, err
+	}
+
+	// We attempt to load all necessary files for the view.
+
+	// We always have a base template.
+	files := []string{
+		baseFilename,
+	}
+
+	// Then we append the named template if it's not the same as base.
+	if name != baseFilename && name != "" {
+		files = append(files, fmt.Sprintf("%s.html", name))
+	}
+
+	// And finally, we include all the partials we can find.
+	partials, err := fs.Glob(viewFS, "partials/*.html")
+	if err != nil {
+		return nil, fmt.Errorf("failed to glob for partials: %w", err)
+	}
+
+	files = append(files, partials...)
+
+	// We now create a new template and parse all the files as templates.
+	t := template.New(baseFilename)
+	templ, err := t.ParseFS(viewFS, files...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse view: %w", err)
+	}
+
+	return &View{
+		name:     name,
+		template: templ,
+	}, nil
+}
+
+// Renders data using the view and writes the result to w.
+func (v *View) Render(w io.Writer, data any) error {
+	return v.template.Execute(w, data)
+}
+
+// validateName checks if all characters are alphanumeric, dashes or underscores.
+func validateName(name string) error {
+	for _, c := range name {
+		if !validViewRune(c) {
+			return fmt.Errorf("invalid character %v in view name: %s", c, name)
+		}
+	}
+	return nil
+}
+
+func validViewRune(r rune) bool {
+	if r == '-' || r == '_' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+		return true
+	}
+
+	return false
+}

--- a/internal/web/view/view.go
+++ b/internal/web/view/view.go
@@ -2,9 +2,9 @@ package view
 
 import (
 	"fmt"
+	"html/template"
 	"io"
 	"io/fs"
-	"text/template"
 )
 
 const baseFilename = "base.html"

--- a/internal/web/view/view_test.go
+++ b/internal/web/view/view_test.go
@@ -1,0 +1,159 @@
+package view_test
+
+import (
+	"bytes"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/willemschots/househunt/internal/web/view"
+)
+
+func TestView_ParseAndRender(t *testing.T) {
+	okTests := map[string]struct {
+		files map[string]string
+		name  string
+		data  any
+		want  string
+	}{
+		"base only": {
+			files: map[string]string{
+				"base.html": `<html>Hello {{ . }}</html>`,
+			},
+			name: "",
+			data: "World!",
+			want: `<html>Hello World!</html>`,
+		},
+		"base only w base name": {
+			files: map[string]string{
+				"base.html": `<html>Hello {{ . }}</html>`,
+			},
+			name: "base",
+			data: "World!",
+			want: `<html>Hello World!</html>`,
+		},
+		"base and home": {
+			files: map[string]string{
+				"base.html": `<html>{{template "content" . }}</html>`,
+				"home.html": `{{define "content"}}<h1>Hello {{ . }}</h1>{{end}}`,
+			},
+			name: "home",
+			data: "World!",
+			want: `<html><h1>Hello World!</h1></html>`,
+		},
+		"base, home and greeting partial": {
+			files: map[string]string{
+				"base.html":              `<html>{{template "content" . }}</html>`,
+				"home.html":              `{{define "content"}}<h1>{{template "greeting" . }}</h1>{{end}}`,
+				"partials/greeting.html": `{{define "greeting"}}Hello {{ . }}{{end}}`,
+			},
+			name: "home",
+			data: "World!",
+			want: `<html><h1>Hello World!</h1></html>`,
+		},
+		"name with all allowed characters": {
+			files: map[string]string{
+				"base.html": `<html>{{template "content" . }}</html>`,
+				"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.html": `{{define "content"}}<h1>Hello {{ . }}</h1>{{end}}`,
+			},
+			name: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_",
+			data: "World!",
+			want: `<html><h1>Hello World!</h1></html>`,
+		},
+	}
+
+	for name, tc := range okTests {
+		t.Run(name, func(t *testing.T) {
+			tempFS := tempFilesForTest(t, tc.files)
+
+			v, err := view.Parse(tempFS, tc.name)
+			if err != nil {
+				t.Fatalf("unexpected error parsing view: %v", err)
+			}
+
+			buf := &bytes.Buffer{}
+			err = v.Render(buf, tc.data)
+			if err != nil {
+				t.Fatalf("unexpected error rendering view: %v", err)
+			}
+
+			got := buf.String()
+			if got != tc.want {
+				t.Errorf("got\n%s\nwant\n%s", got, tc.want)
+			}
+		})
+	}
+
+	parseFails := map[string]struct {
+		files map[string]string
+		name  string
+	}{
+		"no views": {
+			files: map[string]string{},
+			name:  "",
+		},
+		"no base": {
+			files: map[string]string{
+				"home.html": `<h1>Hello {{ . }}</h1>`,
+			},
+			name: "",
+		},
+		"no home": {
+			files: map[string]string{
+				"base.html":  `<html>{{template "content" . }}</html>`,
+				"other.html": `<h1>Hello {{ . }}</h1>`,
+			},
+			name: "home",
+		},
+		"filename with disallowed rune": {
+			files: map[string]string{
+				"base.html": `<html>{{template "content" . }}</html>`,
+				"#.html":    `<h1>Hello {{ . }}</h1>`,
+			},
+			name: "#",
+		},
+	}
+
+	for name, tc := range parseFails {
+		t.Run(name, func(t *testing.T) {
+			tempFS := tempFilesForTest(t, tc.files)
+
+			_, err := view.Parse(tempFS, tc.name)
+			if err == nil {
+				t.Fatalf("expected error, got <nil>")
+			}
+		})
+	}
+}
+
+func tempFilesForTest(t *testing.T, files map[string]string) fs.FS {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "househunt_view_test")
+	if err != nil {
+		t.Fatalf("failed to create temporary directory for views: %v", err)
+	}
+
+	t.Cleanup(func() {
+		err := os.RemoveAll(dir)
+		if err != nil {
+			t.Fatalf("failed to remove temporary directory: %v", err)
+		}
+	})
+
+	for name, content := range files {
+		fn := filepath.Join(dir, name)
+		err := os.MkdirAll(filepath.Dir(fn), 0755)
+		if err != nil {
+			t.Fatalf("failed to create path for temporary file: %v", err)
+		}
+
+		err = os.WriteFile(fn, []byte(content), 0644)
+		if err != nil {
+			t.Fatalf("failed to write temporary file: %v", err)
+		}
+	}
+
+	return os.DirFS(dir)
+}

--- a/internal/web/view/view_test.go
+++ b/internal/web/view/view_test.go
@@ -61,6 +61,14 @@ func TestView_ParseAndRender(t *testing.T) {
 			data: "World!",
 			want: `<html><h1>Hello World!</h1></html>`,
 		},
+		"check data is escaped": {
+			files: map[string]string{
+				"base.html": `<html>{{ . }}</html>`,
+			},
+			name: "",
+			data: "<script>alert('xss')</script>",
+			want: `<html>&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;</html>`,
+		},
 	}
 
 	for name, tc := range okTests {


### PR DESCRIPTION
Before begin implementing a registration endpoint, it will be useful to have some basic HTML rendering in place.

We know this app will contain several views, so it's worth spending a bit of time implementing this upfront. I opted for an approach based on the standard library html templating package.

Every view is composed of:
- `base.html`: a base layout used by all views.
- `{name}.html`: a named layout.
- `partials/*html`: Partial snippets that can be re-used among views.

This should give us enough flexibility for now.

View files are embedded into the Go binary during the build step.

---

As you can see in the last commit, I used the autocomplete to fill in my dependencies and almost ended up using the regular `text/template` package instead of `html/template`.

That would've resulted in fun security issues. I've added a test case to verify we actually escape inputs.

---

Further improvements:
- Right now we parse templates for each request. While handing during development, this is wasted effort in production. I'll add template caching soon.