### PR TITLE
4: SQL Migration files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:1.22-alpine as build
 
 # Git is required for fetching the dependencies.
-RUN apk add --no-cache git
+RUN apk add --no-cache git gcc musl-dev
 
 # Certificates.
 RUN apk --no-cache add ca-certificates
@@ -20,7 +20,7 @@ RUN go mod download
 COPY ./ ./
 
 # Build the binary.
-RUN CGO_ENABLED=0 go build -o /out/server cmd/server/*.go
+RUN CGO_ENABLED=1 go build -o /out/server cmd/server/*.go
 
 # Stage 2. Run the binary.
 FROM scratch AS final

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,7 @@ require (
 	golang.org/x/sync v0.6.0
 )
 
-require golang.org/x/sys v0.18.0 // indirect
+require (
+	github.com/mattn/go-sqlite3 v1.14.22 // indirect
+	golang.org/x/sys v0.18.0 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,9 @@ module github.com/willemschots/househunt
 go 1.22.0
 
 require (
+	github.com/mattn/go-sqlite3 v1.14.22
 	golang.org/x/crypto v0.21.0
 	golang.org/x/sync v0.6.0
 )
 
-require (
-	github.com/mattn/go-sqlite3 v1.14.22 // indirect
-	golang.org/x/sys v0.18.0 // indirect
-)
+require golang.org/x/sys v0.18.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=
 golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOMs=
 golang.org/x/sync v0.6.0 h1:5BMeUDZ7vkXGfEr1x9B4bRcTH4lpkTkpdh0T/J+qjbQ=

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -1,0 +1,220 @@
+package migrate
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io/fs"
+	"strings"
+	"time"
+)
+
+// Migration is a migration that was ran.
+type Migration struct {
+	// Sequence is the number of the migration. Starts at 0.
+	Sequence int
+	Filename string
+	Metadata Metadata
+}
+
+// Equal checks if two migrations are equal.
+func (m Migration) Equal(other Migration) bool {
+	return m.Sequence == other.Sequence &&
+		m.Filename == other.Filename &&
+		m.Metadata.AppVersion == other.Metadata.AppVersion &&
+		m.Metadata.Timestamp.Equal(other.Metadata.Timestamp)
+}
+
+// Metadata contains metadata about a migration.
+// If something does go wrong, this will help with debugging.
+type Metadata struct {
+	AppVersion string
+	Timestamp  time.Time
+}
+
+const migrationsTableQuery = `CREATE TABLE IF NOT EXISTS migrations (
+	sequence    INTEGER PRIMARY KEY,
+	filename    TEXT NOT NULL,
+	app_version TEXT NOT NULL,
+	timestamp   TIMESTAMP NOT NULL
+)
+`
+
+var (
+	// ErrNoTable indicates the migrations table does not exist.
+	ErrNoTable = errors.New("migrations table does not exist")
+	// ErrMigrationsMismatch indicates a mismatch between migrations that ran before and the ones available now.
+	ErrMigrationsMismatch = errors.New("migrations mismatch")
+)
+
+// RunFS runs migrations from the provided fs.FS. It returns a slice of migrations that were
+// run, if no migrations were run it returns an empty slice. RunFS assumes all migration files
+// can be loaded into memory.
+func RunFS(ctx context.Context, db *sql.DB, fileSys fs.FS, meta Metadata) ([]Migration, error) {
+	// Load all migration files from the filesystem.
+	files, err := loadFiles(fileSys)
+	if err != nil {
+		return nil, err
+	}
+
+	// Begin a transaction.
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+
+	// Create migrations table if it does not exist.
+	_, err = tx.Exec(migrationsTableQuery)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create migrations table: %w", err)
+	}
+
+	// Query migrations that ran before.
+	before, err := queryWith(func(q string) (*sql.Rows, error) {
+		return tx.Query(q)
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := migrate(tx, before, files, meta)
+	if err != nil {
+		return nil, err
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		return nil, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return result, nil
+}
+
+func migrate(tx *sql.Tx, ranBefore []Migration, files []file, meta Metadata) ([]Migration, error) {
+	// Check if no files were removed.
+	if len(ranBefore) > len(files) {
+		return nil, fmt.Errorf(
+			"found %d existing migrations but only have %d files: %w",
+			len(ranBefore), len(files), ErrMigrationsMismatch,
+		)
+	}
+
+	// Verify the files that ran before.
+	for i, before := range ranBefore {
+		// Sanity check that sequence is as expected.
+		if i != before.Sequence {
+			return nil, fmt.Errorf(
+				"migration sequence mismatch, wanted %d got %d", i, before.Sequence,
+			)
+		}
+
+		// Check if the filename matches what we expect.
+		if before.Filename != files[i].name {
+			return nil, fmt.Errorf(
+				"migration %d had filename %s, but now encountering %s: %w",
+				i, before.Filename, files[i].name, ErrMigrationsMismatch,
+			)
+		}
+	}
+
+	// prepare the insert statement.
+	stmt, err := tx.Prepare(`INSERT INTO migrations (sequence, filename, app_version, timestamp) VALUES (?, ?, ?, ?)`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare insert statement: %w", err)
+	}
+
+	// files now only contains the migrations that need to be ran.
+	files = files[len(ranBefore):]
+
+	ranNow := make([]Migration, 0)
+	for i, f := range files {
+		_, err := tx.Exec(f.content)
+		if err != nil {
+			return nil, fmt.Errorf("failed to run migration %q: %w", f.name, err)
+		}
+
+		m := Migration{
+			Sequence: len(ranBefore) + i,
+			Filename: f.name,
+			Metadata: meta,
+		}
+
+		ranNow = append(ranNow, m)
+
+		_, err = stmt.Exec(m.Sequence, m.Filename, m.Metadata.AppVersion, m.Metadata.Timestamp)
+		if err != nil {
+			return nil, fmt.Errorf("failed to insert migration: %w", err)
+		}
+	}
+
+	return ranNow, nil
+}
+
+// QueryMigrations queries the given db for all migrations that ran.
+// If the migration table does not exist yet, it returns the ErrNoTable error.
+func QueryMigrations(ctx context.Context, db *sql.DB) ([]Migration, error) {
+	return queryWith(func(q string) (*sql.Rows, error) {
+		return db.QueryContext(ctx, q)
+	})
+}
+
+func queryWith(rowsFunc func(q string) (*sql.Rows, error)) ([]Migration, error) {
+	const q = `SELECT sequence, filename, app_version, timestamp FROM migrations ORDER BY sequence`
+	rows, err := rowsFunc(q)
+	if err != nil {
+		if strings.Contains(err.Error(), "no such table") {
+			return nil, ErrNoTable
+		}
+		return nil, fmt.Errorf("failed to query migrations: %w", err)
+	}
+	defer rows.Close()
+
+	migrations := make([]Migration, 0)
+	for rows.Next() {
+		var m Migration
+		err := rows.Scan(&m.Sequence, &m.Filename, &m.Metadata.AppVersion, &m.Metadata.Timestamp)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan migration: %w", err)
+		}
+
+		migrations = append(migrations, m)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate over rows: %w", err)
+	}
+
+	return migrations, nil
+}
+
+type file struct {
+	name    string
+	content string
+}
+
+func loadFiles(fileSys fs.FS) ([]file, error) {
+	entries, err := fs.ReadDir(fileSys, ".")
+	if err != nil {
+		return nil, fmt.Errorf("failed to read migrations directory: %w", err)
+	}
+
+	files := make([]file, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		content, err := fs.ReadFile(fileSys, entry.Name())
+		if err != nil {
+			return nil, fmt.Errorf("failed to read migration %q: %w", entry.Name(), err)
+		}
+
+		files = append(files, file{
+			name:    entry.Name(),
+			content: string(content),
+		})
+	}
+
+	return files, nil
+}

--- a/internal/migrate/migrate_test.go
+++ b/internal/migrate/migrate_test.go
@@ -1,0 +1,276 @@
+package migrate_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/willemschots/househunt/internal/migrate"
+)
+
+func Test_RunFS(t *testing.T) {
+	t.Run("ok, empty dir", func(t *testing.T) {
+		db := openSQLiteDBForTest(t)
+
+		meta := migrate.Metadata{
+			"v1.0.0", timeRFC3339(t, "2024-03-20T14:56:00Z"),
+		}
+
+		got, err := migrate.RunFS(context.Background(), db, os.DirFS("./testdata/emptydir"), meta)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		assertMigrations(t, got, []migrate.Migration{})
+		assertTable(t, db, []migrate.Migration{})
+	})
+
+	t.Run("ok, subdir is skipped", func(t *testing.T) {
+		db := openSQLiteDBForTest(t)
+
+		meta := migrate.Metadata{
+			"v1.0.0", timeRFC3339(t, "2024-03-20T14:56:00Z"),
+		}
+
+		got, err := migrate.RunFS(context.Background(), db, os.DirFS("./testdata/skip_subdir"), meta)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		want := []migrate.Migration{
+			{
+				Sequence: 0,
+				Filename: "2_create_test_table.sql",
+				Metadata: migrate.Metadata{
+					"v1.0.0", timeRFC3339(t, "2024-03-20T14:56:00Z"),
+				},
+			},
+		}
+		assertMigrations(t, got, want)
+		assertTable(t, db, want)
+		assertNrOfRowsInTestTable(t, db, 0)
+	})
+
+	t.Run("ok, progression of migrations", func(t *testing.T) {
+		db := openSQLiteDBForTest(t)
+
+		metas := []migrate.Metadata{
+			{"v1.0.0", timeRFC3339(t, "2024-03-20T14:56:00Z")},
+			{"v2.0.0", timeRFC3339(t, "2024-04-20T14:56:00Z")},
+			{"v3.0.0", timeRFC3339(t, "2024-05-20T14:56:00Z")},
+		}
+
+		migrations := []migrate.Migration{
+			{
+				Sequence: 0,
+				Filename: "1_create_test_table.sql",
+				Metadata: metas[0],
+			},
+			{
+				Sequence: 1,
+				Filename: "2_add_row_to_test_table.sql",
+				Metadata: metas[1],
+			},
+			{
+				Sequence: 2,
+				Filename: "3_add_another_row.sql",
+				Metadata: metas[2],
+			},
+			{
+				Sequence: 3,
+				Filename: "4_and_one_more.sql",
+				Metadata: metas[2],
+			},
+		}
+
+		t.Run("run_1", func(t *testing.T) {
+			got, err := migrate.RunFS(context.Background(), db, os.DirFS("./testdata/progression/run_1"), metas[0])
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			assertMigrations(t, got, migrations[:1])
+			assertTable(t, db, migrations[:1])
+			assertNrOfRowsInTestTable(t, db, 0)
+		})
+
+		t.Run("run_2", func(t *testing.T) {
+			got, err := migrate.RunFS(context.Background(), db, os.DirFS("./testdata/progression/run_2"), metas[1])
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			assertMigrations(t, got, migrations[1:2])
+			assertTable(t, db, migrations[:2])
+			assertNrOfRowsInTestTable(t, db, 1)
+		})
+
+		t.Run("run_3", func(t *testing.T) {
+			got, err := migrate.RunFS(context.Background(), db, os.DirFS("./testdata/progression/run_3"), metas[2])
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			assertMigrations(t, got, migrations[2:4])
+			assertTable(t, db, migrations[:4])
+			assertNrOfRowsInTestTable(t, db, 3)
+		})
+	})
+
+	t.Run("fail, migration file that was executed was removed from disk", func(t *testing.T) {
+		db := openSQLiteDBForTest(t)
+		metas := []migrate.Metadata{
+			{"v1.0.0", timeRFC3339(t, "2024-03-20T14:56:00Z")},
+			{"v2.0.0", timeRFC3339(t, "2024-04-20T14:56:00Z")},
+		}
+
+		t.Run("run_1", func(t *testing.T) {
+			_, err := migrate.RunFS(context.Background(), db, os.DirFS("./testdata/removal_mismatch/run_1"), metas[0])
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Just check if the migrations ran.
+			assertNrOfRowsInTestTable(t, db, 3)
+		})
+
+		t.Run("run_2", func(t *testing.T) {
+			_, err := migrate.RunFS(context.Background(), db, os.DirFS("./testdata/removal_mismatch/run_2"), metas[1])
+			if !errors.Is(err, migrate.ErrMigrationsMismatch) {
+				t.Fatalf("got %v, want %v (via errors.Is)", err, migrate.ErrMigrationsMismatch)
+			}
+
+			assertNrOfRowsInTestTable(t, db, 3)
+		})
+	})
+
+	t.Run("fail, migration file that was executed was renamed", func(t *testing.T) {
+		db := openSQLiteDBForTest(t)
+		metas := []migrate.Metadata{
+			{"v1.0.0", timeRFC3339(t, "2024-03-20T14:56:00Z")},
+			{"v2.0.0", timeRFC3339(t, "2024-04-20T14:56:00Z")},
+		}
+
+		t.Run("run_1", func(t *testing.T) {
+			_, err := migrate.RunFS(context.Background(), db, os.DirFS("./testdata/rename_mismatch/run_1"), metas[0])
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			// Just check if the migrations ran.
+			assertNrOfRowsInTestTable(t, db, 3)
+		})
+
+		t.Run("run_2", func(t *testing.T) {
+			_, err := migrate.RunFS(context.Background(), db, os.DirFS("./testdata/rename_mismatch/run_2"), metas[1])
+			if !errors.Is(err, migrate.ErrMigrationsMismatch) {
+				t.Fatalf("got %v, want %v (via errors.Is)", err, migrate.ErrMigrationsMismatch)
+			}
+
+			assertNrOfRowsInTestTable(t, db, 3)
+		})
+	})
+}
+
+func Test_QueryMigrations(t *testing.T) {
+	t.Run("fail, no table", func(t *testing.T) {
+		db := openSQLiteDBForTest(t)
+
+		_, err := migrate.QueryMigrations(context.Background(), db)
+		if !errors.Is(err, migrate.ErrNoTable) {
+			t.Fatalf("got %v, want %v (via errors.Is)", err, migrate.ErrNoTable)
+		}
+	})
+}
+
+func openSQLiteDBForTest(t *testing.T) *sql.DB {
+	name := strings.ReplaceAll(t.Name(), string(os.PathSeparator), "_")
+	dbDir, err := os.MkdirTemp(os.TempDir(), name)
+	if err != nil {
+		t.Fatalf("failed to create temporary directory: %v", err)
+	}
+
+	db, err := sql.Open("sqlite3", filepath.Join(dbDir, "test.db"))
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+
+	t.Cleanup(func() {
+		err := db.Close()
+		if err != nil {
+			t.Errorf("failed to close database: %v", err)
+		}
+
+		err = os.RemoveAll(dbDir)
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			t.Errorf("failed to remove database: %v", err)
+		}
+	})
+
+	return db
+}
+
+func assertTable(t *testing.T, db *sql.DB, want []migrate.Migration) {
+	t.Helper()
+
+	got, err := migrate.QueryMigrations(context.Background(), db)
+	if err != nil {
+		t.Fatalf("failed to query migrations: %v", err)
+	}
+
+	assertMigrations(t, got, want)
+}
+
+func assertMigrations(t *testing.T, got, want []migrate.Migration) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Errorf("got\n%+v\nwant\n%+v\n", got, want)
+	}
+
+	if len(want) == 1 && got == nil {
+		t.Errorf("got\n%+v\nwant\n%+v\n", got, want)
+	}
+
+	for i := range got {
+		if !got[i].Equal(want[i]) {
+			t.Errorf("got\n%+v\nwant\n%+v\n", got, want)
+		}
+	}
+}
+
+// assertNrOfRowsInTestTable checks the number of rows in the test_table.
+// The test table is created by our testdata. Some migrations add rows to it,
+// enabling us to test if migrations were executed.
+func assertNrOfRowsInTestTable(t *testing.T, db *sql.DB, want int) {
+	t.Helper()
+
+	row := db.QueryRow("SELECT COUNT(*) FROM test_table")
+
+	var got int
+	err := row.Scan(&got)
+	if err != nil {
+		t.Fatalf("failed to scan test_table: %v", err)
+	}
+
+	if got != want {
+		t.Errorf("got %d, want %d", got, want)
+	}
+}
+
+func timeRFC3339(t *testing.T, v string) time.Time {
+	t.Helper()
+
+	ts, err := time.Parse(time.RFC3339, v)
+	if err != nil {
+		t.Fatalf("failed to parse time: %v", err)
+	}
+
+	return ts
+}

--- a/internal/migrate/testdata/progression/run_1/1_create_test_table.sql
+++ b/internal/migrate/testdata/progression/run_1/1_create_test_table.sql
@@ -1,0 +1,3 @@
+CREATE TABLE test_table (
+  id SERIAL PRIMARY KEY
+);

--- a/internal/migrate/testdata/progression/run_2/1_create_test_table.sql
+++ b/internal/migrate/testdata/progression/run_2/1_create_test_table.sql
@@ -1,0 +1,3 @@
+CREATE TABLE test_table (
+  id SERIAL PRIMARY KEY
+);

--- a/internal/migrate/testdata/progression/run_2/2_add_row_to_test_table.sql
+++ b/internal/migrate/testdata/progression/run_2/2_add_row_to_test_table.sql
@@ -1,0 +1,1 @@
+INSERT INTO test_table (id) VALUES (1);

--- a/internal/migrate/testdata/progression/run_3/1_create_test_table.sql
+++ b/internal/migrate/testdata/progression/run_3/1_create_test_table.sql
@@ -1,0 +1,3 @@
+CREATE TABLE test_table (
+  id SERIAL PRIMARY KEY
+);

--- a/internal/migrate/testdata/progression/run_3/2_add_row_to_test_table.sql
+++ b/internal/migrate/testdata/progression/run_3/2_add_row_to_test_table.sql
@@ -1,0 +1,1 @@
+INSERT INTO test_table (id) VALUES (1);

--- a/internal/migrate/testdata/progression/run_3/3_add_another_row.sql
+++ b/internal/migrate/testdata/progression/run_3/3_add_another_row.sql
@@ -1,0 +1,1 @@
+INSERT INTO test_table (id) VALUES (2);

--- a/internal/migrate/testdata/progression/run_3/4_and_one_more.sql
+++ b/internal/migrate/testdata/progression/run_3/4_and_one_more.sql
@@ -1,0 +1,1 @@
+INSERT INTO test_table (id) VALUES (3);

--- a/internal/migrate/testdata/removal_mismatch/run_1/1_create_test_table.sql
+++ b/internal/migrate/testdata/removal_mismatch/run_1/1_create_test_table.sql
@@ -1,0 +1,3 @@
+CREATE TABLE test_table (
+  id SERIAL PRIMARY KEY
+);

--- a/internal/migrate/testdata/removal_mismatch/run_1/2_add_row_to_test_table.sql
+++ b/internal/migrate/testdata/removal_mismatch/run_1/2_add_row_to_test_table.sql
@@ -1,0 +1,1 @@
+INSERT INTO test_table (id) VALUES (1);

--- a/internal/migrate/testdata/removal_mismatch/run_1/3_add_another_row.sql
+++ b/internal/migrate/testdata/removal_mismatch/run_1/3_add_another_row.sql
@@ -1,0 +1,1 @@
+INSERT INTO test_table (id) VALUES (2);

--- a/internal/migrate/testdata/removal_mismatch/run_1/4_and_one_more.sql
+++ b/internal/migrate/testdata/removal_mismatch/run_1/4_and_one_more.sql
@@ -1,0 +1,1 @@
+INSERT INTO test_table (id) VALUES (3);

--- a/internal/migrate/testdata/removal_mismatch/run_2/1_create_test_table.sql
+++ b/internal/migrate/testdata/removal_mismatch/run_2/1_create_test_table.sql
@@ -1,0 +1,3 @@
+CREATE TABLE test_table (
+  id SERIAL PRIMARY KEY
+);

--- a/internal/migrate/testdata/removal_mismatch/run_2/2_add_row_to_test_table.sql
+++ b/internal/migrate/testdata/removal_mismatch/run_2/2_add_row_to_test_table.sql
@@ -1,0 +1,1 @@
+INSERT INTO test_table (id) VALUES (1);

--- a/internal/migrate/testdata/removal_mismatch/run_2/4_and_one_more.sql
+++ b/internal/migrate/testdata/removal_mismatch/run_2/4_and_one_more.sql
@@ -1,0 +1,1 @@
+INSERT INTO test_table (id) VALUES (3);

--- a/internal/migrate/testdata/rename_mismatch/run_1/1_create_test_table.sql
+++ b/internal/migrate/testdata/rename_mismatch/run_1/1_create_test_table.sql
@@ -1,0 +1,3 @@
+CREATE TABLE test_table (
+  id SERIAL PRIMARY KEY
+);

--- a/internal/migrate/testdata/rename_mismatch/run_1/2_add_row_to_test_table.sql
+++ b/internal/migrate/testdata/rename_mismatch/run_1/2_add_row_to_test_table.sql
@@ -1,0 +1,1 @@
+INSERT INTO test_table (id) VALUES (1);

--- a/internal/migrate/testdata/rename_mismatch/run_1/3_add_another_row.sql
+++ b/internal/migrate/testdata/rename_mismatch/run_1/3_add_another_row.sql
@@ -1,0 +1,1 @@
+INSERT INTO test_table (id) VALUES (2);

--- a/internal/migrate/testdata/rename_mismatch/run_1/4_and_one_more.sql
+++ b/internal/migrate/testdata/rename_mismatch/run_1/4_and_one_more.sql
@@ -1,0 +1,1 @@
+INSERT INTO test_table (id) VALUES (3);

--- a/internal/migrate/testdata/rename_mismatch/run_2/1_create_test_table.sql
+++ b/internal/migrate/testdata/rename_mismatch/run_2/1_create_test_table.sql
@@ -1,0 +1,3 @@
+CREATE TABLE test_table (
+  id SERIAL PRIMARY KEY
+);

--- a/internal/migrate/testdata/rename_mismatch/run_2/2_add_row_to_test_table.sql
+++ b/internal/migrate/testdata/rename_mismatch/run_2/2_add_row_to_test_table.sql
@@ -1,0 +1,1 @@
+INSERT INTO test_table (id) VALUES (1);

--- a/internal/migrate/testdata/rename_mismatch/run_2/3_add_another_row_RENAMED.sql
+++ b/internal/migrate/testdata/rename_mismatch/run_2/3_add_another_row_RENAMED.sql
@@ -1,0 +1,1 @@
+INSERT INTO test_table (id) VALUES (2);

--- a/internal/migrate/testdata/rename_mismatch/run_2/4_and_one_more.sql
+++ b/internal/migrate/testdata/rename_mismatch/run_2/4_and_one_more.sql
@@ -1,0 +1,1 @@
+INSERT INTO test_table (id) VALUES (3);

--- a/internal/migrate/testdata/skip_subdir/2_create_test_table.sql
+++ b/internal/migrate/testdata/skip_subdir/2_create_test_table.sql
@@ -1,0 +1,3 @@
+CREATE TABLE test_table (
+  id SERIAL PRIMARY KEY
+);


### PR DESCRIPTION
This PR introduces the `internal/migrate` package. It runs migrations against a SQL database.

The migrations are modeled as a "append only" list of migration files.

The migrations will run during app startup and will:
1. Load all migration files from disk.
2. Create a `migrations` table if it doesn't already exist. 
3. Query existing migrations from the database.
4. Verify that no weird changes crept it.
5. Figure out which migration files have not been ran yet.
6. Run these migration files in filename order.

This PR only adds the functionality, it doesn't run or contain any migrations yet.

---

### Why no up & down?

Some migration systems support "up" and "down" migrations. The idea is that "down" migrations allow you to roll back the database to an earlier version. However, not all database operations can actually be undone, any data deleted can't be restored. Making the entire model a bit awkward IMO.

I prefer modelling my migrations as an "append only" list of changes that were executed against the database, if I need to roll back something I will add a new migration that undoes the previous one.
