### PR TITLE
4: Add email address type

### DIFF
--- a/internal/auth/password.go
+++ b/internal/auth/password.go
@@ -22,7 +22,7 @@ const (
 	SecretMarker = "<!PASSWORD_REDACTED!>"
 )
 
-var InvalidPasswordErr = fmt.Errorf("invalid password")
+var ErrInvalidPassword = fmt.Errorf("invalid password")
 
 // Password is a plaintext password.
 //
@@ -41,7 +41,7 @@ type Password struct {
 // It errors if the password is too short or too long.
 func ParsePassword(pwd string) (Password, error) {
 	if len(pwd) < minPasswordBytes || len(pwd) > maxPasswordBytes {
-		return Password{}, InvalidPasswordErr
+		return Password{}, ErrInvalidPassword
 	}
 
 	return Password{

--- a/internal/email/address.go
+++ b/internal/email/address.go
@@ -1,0 +1,35 @@
+package email
+
+import (
+	"errors"
+	"net/mail"
+	"strings"
+)
+
+// ErrInvalidEmail indicates an email address is not valid.
+var ErrInvalidEmail = errors.New("invalid email address")
+
+// Address is how househunt represents email addresses.
+type Address string
+
+// ParseAddress parses the given string and checks if it's shaped like an email address.
+// It returns an error if the input is not a valid email address.
+// Note that this doesn't guarantee the email address actually exists, it only checks the format.
+func ParseAddress(raw string) (Address, error) {
+	trimmed := strings.TrimSpace(raw)
+
+	addr, err := mail.ParseAddress(trimmed)
+	if err != nil {
+		return Address(""), ErrInvalidEmail
+	}
+
+	// mail.ParseAddress accepts addresses with names and comments:
+	// "Alice <alice@example.com>(comment)".
+	//
+	// We only want to accept inputs that consist of the address part.
+	if addr.Address != trimmed {
+		return Address(""), ErrInvalidEmail
+	}
+
+	return Address(addr.Address), nil
+}

--- a/internal/email/address_test.go
+++ b/internal/email/address_test.go
@@ -1,0 +1,60 @@
+package email_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/willemschots/househunt/internal/email"
+)
+
+func Test_ParseAddress(t *testing.T) {
+	okTests := map[string]struct {
+		raw  string
+		want email.Address
+	}{
+		"shortest possible": {
+			raw:  "a@b",
+			want: "a@b",
+		},
+		"typical": {
+			raw:  "alice@example.com",
+			want: "alice@example.com",
+		},
+		"whitespace is trimmed": {
+			raw:  " 	alice@example.com  ",
+			want: "alice@example.com",
+		},
+	}
+
+	for name, tc := range okTests {
+		t.Run(name, func(t *testing.T) {
+			got, err := email.ParseAddress(tc.raw)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+
+	failTests := map[string]string{
+		"empty":                 "",
+		"whitespace only":       " 	",
+		"missing @":             "alice.example.com",
+		"missing domain":        "alice@",
+		"missing local part":    "@example.com",
+		"with name":             "Alice <alice@example.com>",
+		"with name and comment": "Alice <alice@example.com>(comment)",
+	}
+
+	for name, raw := range failTests {
+		t.Run(name, func(t *testing.T) {
+			_, err := email.ParseAddress(raw)
+			if !errors.Is(err, email.ErrInvalidEmail) {
+				t.Fatalf("expected error to be email.ErrInvalidEmail via errors.Is, but got %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds an `email.Address` type to represent email address shaped data in househunt. We require such a data type before we can continue implementing account registration.

Note that this is generally considered personally identifiable information (PII) so we should be careful with how we handle this.