### PR TITLE
4: Initial work on account registration

### DIFF
--- a/internal/auth/argon2_hash_test.go
+++ b/internal/auth/argon2_hash_test.go
@@ -10,14 +10,14 @@ import (
 
 func failTextToArgon2Hash() map[string]string {
 	return map[string]string{
-		"wrong variant":           "$argon2i$v=19$m=47104,t=1,p=1$fYJT8cAysfuYCBjxTEmCkaCz0RfRtlLQOw2Fj8gM5Uw$DVpK1dNdPRmhL8oTSo+RlA",
-		"non-numeric version":     "$argon2id$v=abc$m=47104,t=1,p=1$fYJT8cAysfuYCBjxTEmCkaCz0RfRtlLQOw2Fj8gM5Uw$DVpK1dNdPRmhL8oTSo+RlA",
-		"non-matching version":    "$argon2id$v=18$m=47104,t=1,p=1$fYJT8cAysfuYCBjxTEmCkaCz0RfRtlLQOw2Fj8gM5Uw$DVpK1dNdPRmhL8oTSo+RlA",
-		"non-numeric memory":      "$argon2id$v=19$m=abc,t=1,p=1$fYJT8cAysfuYCBjxTEmCkaCz0RfRtlLQOw2Fj8gM5Uw$DVpK1dNdPRmhL8oTSo+RlA",
-		"non-numeric iterations":  "$argon2id$v=19$m=47104,t=abc,p=1$fYJT8cAysfuYCBjxTEmCkaCz0RfRtlLQOw2Fj8gM5Uw$DVpK1dNdPRmhL8oTSo+RlA",
-		"non-numeric parallelism": "$argon2id$v=19$m=47104,t=1,p=abc$fYJT8cAysfuYCBjxTEmCkaCz0RfRtlLQOw2Fj8gM5Uw$DVpK1dNdPRmhL8oTSo+RlA",
-		"non-base64 salt":         "$argon2id$v=19$m=47104,t=1,p=1$???????????????????????????????????????????$DVpK1dNdPRmhL8oTSo+RlA",
-		"non-base64 hash":         "$argon2id$v=19$m=47104,t=1,p=1$fYJT8cAysfuYCBjxTEmCkaCz0RfRtlLQOw2Fj8gM5Uw$??????????????????????",
+		"fail, wrong variant":           "$argon2i$v=19$m=47104,t=1,p=1$fYJT8cAysfuYCBjxTEmCkaCz0RfRtlLQOw2Fj8gM5Uw$DVpK1dNdPRmhL8oTSo+RlA",
+		"fail, non-numeric version":     "$argon2id$v=abc$m=47104,t=1,p=1$fYJT8cAysfuYCBjxTEmCkaCz0RfRtlLQOw2Fj8gM5Uw$DVpK1dNdPRmhL8oTSo+RlA",
+		"fail, non-matching version":    "$argon2id$v=18$m=47104,t=1,p=1$fYJT8cAysfuYCBjxTEmCkaCz0RfRtlLQOw2Fj8gM5Uw$DVpK1dNdPRmhL8oTSo+RlA",
+		"fail, non-numeric memory":      "$argon2id$v=19$m=abc,t=1,p=1$fYJT8cAysfuYCBjxTEmCkaCz0RfRtlLQOw2Fj8gM5Uw$DVpK1dNdPRmhL8oTSo+RlA",
+		"fail, non-numeric iterations":  "$argon2id$v=19$m=47104,t=abc,p=1$fYJT8cAysfuYCBjxTEmCkaCz0RfRtlLQOw2Fj8gM5Uw$DVpK1dNdPRmhL8oTSo+RlA",
+		"fail, non-numeric parallelism": "$argon2id$v=19$m=47104,t=1,p=abc$fYJT8cAysfuYCBjxTEmCkaCz0RfRtlLQOw2Fj8gM5Uw$DVpK1dNdPRmhL8oTSo+RlA",
+		"fail, non-base64 salt":         "$argon2id$v=19$m=47104,t=1,p=1$???????????????????????????????????????????$DVpK1dNdPRmhL8oTSo+RlA",
+		"fail, non-base64 hash":         "$argon2id$v=19$m=47104,t=1,p=1$fYJT8cAysfuYCBjxTEmCkaCz0RfRtlLQOw2Fj8gM5Uw$??????????????????????",
 	}
 }
 
@@ -47,7 +47,7 @@ func Test_Argon2Hash_MarshalText(t *testing.T) {
 	}
 }
 
-func Test_ParseArgon2Hash(t *testing.T) {
+func Test_Argon2Hash_ParseArgon2Hash(t *testing.T) {
 	for name, tc := range passwordTests() {
 		t.Run(name, func(t *testing.T) {
 			got, err := auth.ParseArgon2Hash(tc.hashStr)
@@ -64,7 +64,7 @@ func Test_ParseArgon2Hash(t *testing.T) {
 	for name, txt := range failTextToArgon2Hash() {
 		t.Run(name, func(t *testing.T) {
 			_, err := auth.ParseArgon2Hash(txt)
-			if err == nil || !errors.Is(err, auth.ErrInvalidArgon2Hash) {
+			if !errors.Is(err, auth.ErrInvalidArgon2Hash) {
 				t.Errorf("expected error to match (using errors.Is)\n%v\ngot\n%v\n", auth.ErrInvalidArgon2Hash, err)
 			}
 		})
@@ -90,7 +90,7 @@ func Test_Argon2Hash_UnmarshalText(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			var got auth.Argon2Hash
 			err := got.UnmarshalText([]byte(txt))
-			if err == nil || !errors.Is(err, auth.ErrInvalidArgon2Hash) {
+			if !errors.Is(err, auth.ErrInvalidArgon2Hash) {
 				t.Errorf("expected errors to match (using errors.Is)\n%v\ngot\n%v\n", auth.ErrInvalidArgon2Hash, err)
 			}
 		})
@@ -116,7 +116,7 @@ func Test_Argon2Hash_Scan(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			var got auth.Argon2Hash
 			err := got.Scan(txt)
-			if err == nil || !errors.Is(err, auth.ErrInvalidArgon2Hash) {
+			if !errors.Is(err, auth.ErrInvalidArgon2Hash) {
 				t.Errorf("expected errors to match (using errors.Is)\n%v\ngot\n%v\n", auth.ErrInvalidArgon2Hash, err)
 			}
 		})

--- a/internal/auth/db/store_test.go
+++ b/internal/auth/db/store_test.go
@@ -419,7 +419,7 @@ func testEmailToken(t *testing.T, modFunc func(*auth.EmailToken)) auth.EmailToke
 		TokenHash:  argon2Hash(t, "$argon2id$v=19$m=47104,t=1,p=1$CkX5zzYLJMWm0y/17eScyw$Qfah+NewdsdeF0+iV72mShZhRO93Qwzdj17TUZCH6ZU"),
 		UserID:     1,
 		Email:      "alice@example.com",
-		Purpose:    auth.EmailTokenPurposeActivate,
+		Purpose:    auth.TokenPurposeActivate,
 		CreatedAt:  time.Time{},
 		ConsumedAt: nil,
 	}

--- a/internal/auth/email_token.go
+++ b/internal/auth/email_token.go
@@ -15,7 +15,7 @@ const (
 
 var ErrInvalidToken = errors.New("invalid token")
 
-// EmailToken contains the state of a random token that is sent via email.
+// EmailToken contains the state of a token that was sent via email.
 // Such tokens should be only used once and have a limited lifetime.
 type EmailToken struct {
 	ID int
@@ -24,17 +24,17 @@ type EmailToken struct {
 	TokenHash  Argon2Hash
 	UserID     int
 	Email      email.Address
-	Purpose    EmailTokenPurpose
+	Purpose    TokenPurpose
 	CreatedAt  time.Time
 	ConsumedAt *time.Time
 }
 
-// EmailTokenPurpose represents the purpose of an email token.
-type EmailTokenPurpose string
+// TokenPurpose is the purpose of an email token.
+type TokenPurpose string
 
 const (
-	// EmailTokenPurposeActivate indicates an email token is for activating an account.
-	EmailTokenPurposeActivate EmailTokenPurpose = "activate"
+	// TokenPurposeActivate indicates a token should be used to activate an account.
+	TokenPurposeActivate TokenPurpose = "activate"
 )
 
 // Token is a random token that is sent via email.

--- a/internal/auth/email_token.go
+++ b/internal/auth/email_token.go
@@ -1,12 +1,22 @@
 package auth
 
 import (
+	"encoding/hex"
+	"errors"
+	"log/slog"
 	"time"
 
 	"github.com/willemschots/househunt/internal/email"
 )
 
-// EmailToken contains the data for an email token.
+const (
+	tokenLen = 32
+)
+
+var ErrInvalidToken = errors.New("invalid token")
+
+// EmailToken contains the state of a random token that is sent via email.
+// Such tokens should be only used once and have a limited lifetime.
 type EmailToken struct {
 	ID int
 	// TokenHash is the hash of the token. We hash the token to prevent someone with
@@ -26,3 +36,55 @@ const (
 	// EmailTokenPurposeActivate indicates an email token is for activating an account.
 	EmailTokenPurposeActivate EmailTokenPurpose = "activate"
 )
+
+// Token is a random token that is sent via email.
+//
+// The only time a token should be provided in plaintext is as part of
+// the email to the user. Tokens are confidential and should never be
+// exposed in logs or persisted in plaintext.
+type Token [tokenLen]byte
+
+// GenerateToken creates a new random token.
+func GenerateToken() (Token, error) {
+	b, err := genRandomBytes(tokenLen)
+	if err != nil {
+		return [tokenLen]byte{}, err
+	}
+	return [tokenLen]byte(b), nil
+}
+
+// ParseToken parses a token from a string.
+func ParseToken(raw string) (Token, error) {
+	if len(raw) != tokenLen*2 {
+		return [tokenLen]byte{}, ErrInvalidToken
+	}
+
+	b, err := hex.DecodeString(raw)
+	if err != nil {
+		return [tokenLen]byte{}, ErrInvalidToken
+	}
+
+	return [tokenLen]byte(b), nil
+}
+
+// String returns the string representation of the token.
+// As opposed to a Password this allowed, we need to embed the
+// token in emails.
+func (t Token) String() string {
+	return hex.EncodeToString(t[:])
+}
+
+// Hash hashes the token using the argon2id algorithm.
+func (t Token) Hash() (Argon2Hash, error) {
+	return hashBytes(t[:])
+}
+
+// Match checks if the token matches the given hash.
+func (t Token) Match(h Argon2Hash) bool {
+	return matchHash(h, t[:])
+}
+
+// LogValue implements the slog.Valuer interface.
+func (t Token) LogValue() slog.Value {
+	return slog.StringValue(SecretMarker)
+}

--- a/internal/auth/email_token_test.go
+++ b/internal/auth/email_token_test.go
@@ -1,0 +1,151 @@
+package auth_test
+
+import (
+	"bytes"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/willemschots/househunt/internal/auth"
+)
+
+func failTextToToken() map[string]string {
+	return map[string]string{
+		"fail, empty":              "",
+		"fail, too short":          "010203040506070809101112131415161718192021222324252627282930313",
+		"fail, too long":           "01020304050607080910111213141516171819202122232425262728293031323",
+		"fail, non-hex characters": "010203040506070809101112131415161718192021222324252627282930313g",
+	}
+}
+
+func Test_Token_GenerateToken(t *testing.T) {
+	t.Run("ok, generate a token", func(t *testing.T) {
+		tok, err := auth.GenerateToken()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(tok) != 32 {
+			t.Fatalf("got %d want %d", len(tok), 32)
+		}
+	})
+}
+
+func Test_Token_ParseString(t *testing.T) {
+	t.Run("ok, valid", func(t *testing.T) {
+		want := auth.Token{
+			0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+			0x09, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16,
+			0x17, 0x18, 0x19, 0x20, 0x21, 0x22, 0x23, 0x24,
+			0x25, 0x26, 0x27, 0x28, 0x29, 0x30, 0x31, 0x32,
+		}
+
+		raw := "0102030405060708091011121314151617181920212223242526272829303132"
+		got, err := auth.ParseToken(raw)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if got != want {
+			t.Fatalf("got\n%v\nwant\n%v\n", got, want)
+		}
+
+		if got.String() != raw {
+			t.Fatalf("got\n%s\nwant\n%s\n", got.String(), raw)
+		}
+	})
+
+	for name, raw := range failTextToToken() {
+		t.Run(name, func(t *testing.T) {
+			_, err := auth.ParseToken(raw)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+
+			if !errors.Is(err, auth.ErrInvalidToken) {
+				t.Fatalf("expected error %v, got %v ", auth.ErrInvalidToken, err)
+
+			}
+		})
+	}
+}
+
+func Test_Token_HashMatch(t *testing.T) {
+	t.Run("ok, hash and match", func(t *testing.T) {
+		tok, err := auth.GenerateToken()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		hash, err := tok.Hash()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !tok.Match(hash) {
+			t.Fatalf("expected token to match hash, got no match")
+		}
+	})
+
+	t.Run("ok, match existing token", func(t *testing.T) {
+		raw := "0102030405060708091011121314151617181920212223242526272829303132"
+		tok, err := auth.ParseToken(raw)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		hashStr := "$argon2id$v=19$m=47104,t=1,p=1$rSfnv7764FDPkWSk1zCRfA$nFV41xxTo0rNWkAXtozwgyQWTzon/TF58j6+ZDhz1Xg"
+		hash, err := auth.ParseArgon2Hash(hashStr)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !tok.Match(hash) {
+			t.Fatalf("expected token to match hash, got no match")
+		}
+	})
+
+	t.Run("ok, no match", func(t *testing.T) {
+		raw := "3202030405060708091011121314151617181920212223242526272829303132"
+		tok, err := auth.ParseToken(raw)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		hashStr := "$argon2id$v=19$m=47104,t=1,p=1$rSfnv7764FDPkWSk1zCRfA$nFV41xxTo0rNWkAXtozwgyQWTzon/TF58j6+ZDhz1Xg"
+		hash, err := auth.ParseArgon2Hash(hashStr)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if tok.Match(hash) {
+			t.Fatalf("did not expect token to match, but it did")
+		}
+	})
+}
+
+func Test_Token_PreventExposure(t *testing.T) {
+	t.Run("ok, log output", func(t *testing.T) {
+		tok, err := auth.GenerateToken()
+		if err != nil {
+			t.Fatalf("failed to generate token: %v", err)
+		}
+
+		buf := &bytes.Buffer{}
+
+		logger := slog.New(slog.NewTextHandler(buf, nil))
+
+		logger.Info("attempting to log a password", "password", tok)
+
+		s := buf.String()
+		if !strings.Contains(s, auth.SecretMarker) {
+			t.Errorf("log output\n%s\ndoes not contain secret marker: %s", s, auth.SecretMarker)
+		}
+
+		raw := tok.String()
+		if strings.Contains(s, raw) {
+			t.Errorf("log output\n%s\ncontains raw password: %s", s, raw)
+		}
+	})
+}

--- a/internal/auth/email_token_test.go
+++ b/internal/auth/email_token_test.go
@@ -27,7 +27,7 @@ func Test_Token_GenerateToken(t *testing.T) {
 		}
 
 		if len(tok) != 32 {
-			t.Fatalf("got %d want %d", len(tok), 32)
+			t.Fatalf("got %d want %d tok(%v)", len(tok), 32, tok)
 		}
 	})
 }

--- a/internal/auth/password.go
+++ b/internal/auth/password.go
@@ -1,11 +1,7 @@
 package auth
 
 import (
-	"crypto/rand"
-	"crypto/subtle"
 	"fmt"
-
-	"golang.org/x/crypto/argon2"
 )
 
 const (
@@ -18,8 +14,8 @@ const (
 	maxPasswordBytes = 512
 
 	// SecretMarker is a string we can look for in logs to see if the app
-	// is accidentally exposing passwords.
-	SecretMarker = "<!PASSWORD_REDACTED!>"
+	// is accidentally exposing secrets.
+	SecretMarker = "<!SECRET_REDACTED!>"
 )
 
 var ErrInvalidPassword = fmt.Errorf("invalid password")
@@ -51,43 +47,12 @@ func ParsePassword(pwd string) (Password, error) {
 
 // Match checks if the plaintext password matches the given hash.
 func (p Password) Match(h Argon2Hash) bool {
-	// Hash the plaintext password with the same parameters as the provided hash.
-	other := argon2.IDKey(p.plain, h.Salt, h.Iterations, h.MemoryKiB, h.Parallelism, uint32(len(h.Hash)))
-
-	// use subtle to compare the two hashes in constant time to avoid timing attacks.
-	return subtle.ConstantTimeCompare(other, h.Hash) == 1
+	return matchHash(h, p.plain)
 }
 
 // Hash hashes the plaintext password using the argon2id algorithm.
 func (p Password) Hash() (Argon2Hash, error) {
-	// First we generate a salt.
-	salt, err := generateSalt()
-	if err != nil {
-		return Argon2Hash{}, fmt.Errorf("failed to generate salt: %w", err)
-	}
-
-	// Then we hash the password.
-	hash := argon2.IDKey(p.plain, salt, iterations, memoryKiB, parallelism, keyLen)
-
-	return Argon2Hash{
-		Variant:     variant,
-		Version:     argon2.Version,
-		MemoryKiB:   memoryKiB,
-		Iterations:  iterations,
-		Parallelism: parallelism,
-		Salt:        salt,
-		Hash:        hash,
-	}, nil
-}
-
-func generateSalt() ([]byte, error) {
-	salt := make([]byte, saltLen)
-	_, err := rand.Read(salt)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read random bytes: %w", err)
-	}
-
-	return salt, nil
+	return hashBytes(p.plain)
 }
 
 func (p Password) String() string {

--- a/internal/auth/password_test.go
+++ b/internal/auth/password_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/willemschots/househunt/internal/auth"
 )
 
-func Test_ParseHashMatchPassword(t *testing.T) {
+func Test_Password_ParseHashMatch(t *testing.T) {
 	for name, tc := range passwordTests() {
 		t.Run(name, func(t *testing.T) {
 			pwd, err := auth.ParsePassword(tc.raw)

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -2,8 +2,16 @@ package auth
 
 import (
 	"context"
+	"errors"
+	"sync"
+	"time"
 
 	"github.com/willemschots/househunt/internal/email"
+	"github.com/willemschots/househunt/internal/errorz"
+)
+
+var (
+	ErrDuplicateAccount = errors.New("duplicate account")
 )
 
 // Store provides access to the user store.
@@ -25,4 +33,134 @@ type Tx interface {
 	CreateEmailToken(t *EmailToken) error
 	UpdateEmailToken(t *EmailToken) error
 	FindEmailTokenByID(id int) (EmailToken, error)
+}
+
+// ErrFunc is a function that handles errors.
+type ErrFunc func(error)
+
+// Service is the type that provides the main rules for
+// authentication.
+type Service struct {
+	store       Store
+	wg          *sync.WaitGroup
+	errHandler  ErrFunc
+	workTimeout time.Duration // amount of time the "worker" goroutines are allowed to run.
+}
+
+func NewService(s Store, errHandler ErrFunc, workTimeout time.Duration) *Service {
+	svc := &Service{
+		store:       s,
+		wg:          &sync.WaitGroup{},
+		errHandler:  errHandler,
+		workTimeout: workTimeout,
+	}
+
+	return svc
+}
+
+func (s *Service) Close() {
+	s.wg.Wait()
+}
+
+// RegisterAccount registers a new account for the provided credentials.
+func (s *Service) RegisterAccount(ctx context.Context, c Credentials) error {
+	// Hash the password.
+	pwdHash, err := c.Password.Hash()
+	if err != nil {
+		return err
+	}
+
+	user := User{
+		Email:        c.Email,
+		PasswordHash: pwdHash,
+		IsActive:     false,
+	}
+
+	// The main logic to create a new user is run in a separate goroutine.
+	// This is for two reaons:
+	// - Waiting for the email to be send might slow down sending a response.
+	// - Information leakage. Timing difference between existing/non-existing
+	//   accounts could lead to account enumeration attacks.
+	s.wg.Add(1)
+	go func() {
+		wCtx, cancel := context.WithTimeout(ctx, s.workTimeout)
+		defer cancel()
+		s.createNewUser(wCtx, user)
+		s.wg.Done()
+	}()
+
+	// Note that we don't let the caller know if the account was created or not.
+	// This is by design, again to prevent information leakage.
+	return nil
+}
+
+func (s *Service) createNewUser(ctx context.Context, user User) {
+	token, err := GenerateToken()
+	if err != nil {
+		s.errHandler(err)
+		return
+	}
+
+	tokenHash, err := token.Hash()
+	if err != nil {
+		s.errHandler(err)
+		return
+	}
+
+	s.inTx(ctx, func(tx Tx) error {
+		_, err := tx.FindUserByEmail(user.Email)
+		if err == nil {
+			return ErrDuplicateAccount
+		}
+
+		if !errors.Is(err, errorz.ErrNotFound) {
+			return err
+		}
+
+		err = tx.CreateUser(&user)
+		if err != nil {
+			return err
+		}
+
+		emailToken := EmailToken{
+			TokenHash:  tokenHash,
+			UserID:     user.ID,
+			Email:      user.Email,
+			Purpose:    TokenPurposeActivate,
+			ConsumedAt: nil,
+		}
+
+		err = tx.CreateEmailToken(&emailToken)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	// TODO: Send registration email.
+}
+
+func (s *Service) inTx(ctx context.Context, f func(tx Tx) error) {
+	tx, err := s.store.BeginTx(ctx)
+	if err != nil {
+		s.errHandler(err)
+		return
+	}
+
+	err = f(tx)
+	if err != nil {
+		rBackErr := tx.Rollback()
+		if rBackErr != nil {
+			err = errors.Join(err, rBackErr)
+		}
+		s.errHandler(err)
+		return
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		s.errHandler(err)
+		return
+	}
 }

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -1,0 +1,136 @@
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/willemschots/househunt/internal/auth"
+	"github.com/willemschots/househunt/internal/auth/db"
+	"github.com/willemschots/househunt/internal/db/testdb"
+	"github.com/willemschots/househunt/internal/email"
+)
+
+func Test_Service_RegisterAccount(t *testing.T) {
+	setup := func(t *testing.T) (*auth.Service, *errList) {
+		testDB := db.New(testdb.RunWhile(t, true), func() time.Time {
+			return time.Now().Round(0)
+		})
+
+		errs := &errList{
+			mutex: &sync.Mutex{},
+			errs:  make([]error, 0),
+		}
+		svc := auth.NewService(testDB, errs.AppendErr, time.Second)
+
+		return svc, errs
+	}
+
+	t.Run("ok, register account", func(t *testing.T) {
+		svc, errs := setup(t)
+
+		credentials := auth.Credentials{
+			Email:    emailAddress(t, "test@example.com"),
+			Password: password(t, "reallyStrongPassword1"),
+		}
+		err := svc.RegisterAccount(context.Background(), credentials)
+		if err != nil {
+			t.Fatalf("failed to register account: %v", err)
+		}
+
+		// Wait for service goroutines to finish.
+		svc.Close()
+
+		errs.assertNoError(t)
+
+		// TODO: Assert that an email was send to the email address.
+	})
+
+	t.Run("fail async, register account with same email", func(t *testing.T) {
+		svc, errs := setup(t)
+
+		credentials := auth.Credentials{
+			Email:    emailAddress(t, "test@example.com"),
+			Password: password(t, "reallyStrongPassword1"),
+		}
+		err := svc.RegisterAccount(context.Background(), credentials)
+		if err != nil {
+			t.Fatalf("failed to register account: %v", err)
+		}
+
+		// Register again, notice this outputs no error.
+		err = svc.RegisterAccount(context.Background(), credentials)
+		if err != nil {
+			t.Fatalf("failed to register account: %v", err)
+		}
+
+		// Wait for service goroutines to finish.
+		svc.Close()
+
+		// However, it does output an error to the err handler.
+		errs.assertErrorIs(t, auth.ErrDuplicateAccount)
+
+		// TODO: Assert only a single email was send.
+	})
+}
+
+type errList struct {
+	mutex *sync.Mutex
+	errs  []error
+}
+
+func (e *errList) AppendErr(err error) {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
+	if e.errs == nil {
+		e.errs = make([]error, 0)
+	}
+	e.errs = append(e.errs, err)
+}
+
+func (e *errList) assertNoError(t *testing.T) {
+	t.Helper()
+
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
+	if len(e.errs) > 0 {
+		t.Fatalf("unexpected errors: %v", e.errs)
+	}
+}
+
+func (e *errList) assertErrorIs(t *testing.T, err error) {
+	t.Helper()
+
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+
+	if len(e.errs) != 1 || !errors.Is(e.errs[0], err) {
+		t.Fatalf("expected error %v, got %v via errors.Is()", err, e.errs)
+	}
+}
+
+func emailAddress(t *testing.T, raw string) email.Address {
+	t.Helper()
+
+	e, err := email.ParseAddress(raw)
+	if err != nil {
+		t.Fatalf("failed to parse email: %v", err)
+	}
+
+	return e
+}
+
+func password(t *testing.T, raw string) auth.Password {
+	t.Helper()
+
+	p, err := auth.ParsePassword(raw)
+	if err != nil {
+		t.Fatalf("failed to parse password: %v", err)
+	}
+
+	return p
+}

--- a/internal/auth/user.go
+++ b/internal/auth/user.go
@@ -15,3 +15,9 @@ type User struct {
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
 }
+
+// Credentials are used to authenticate users.
+type Credentials struct {
+	Password Password
+	Email    email.Address
+}


### PR DESCRIPTION
This PR adds the `auth.Service`.

This will be the part that brings together all the work we did on the `auth` and `auth/db` packages. The methods on the service will be called by the HTTP handlers.

## Registering accounts

This PR also contains the service implementation for registering accounts. The only thing that is still missing is a type to actually send the emails to the user.

## Token type

This PR also adds the `auth.Token` type, it's similar to `auth.Password` but randomly generated and can be represented as a plaintext so that it can be emailed to the user.