### PR TITLE
14-build-data: use embedded build data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,16 +20,16 @@ RUN go mod download
 COPY ./ ./
 
 # Build the server binary.
-RUN CGO_ENABLED=1 go build -o /out/server/server cmd/server/*.go
+RUN CGO_ENABLED=1 go build -o /out/server ./cmd/server
 
-# Use ldd to list the dynamicly linked dependencies and copy them to the output directory.
-RUN ldd /out/server/server | tr -s [:blank:] '\n' | grep ^/ | xargs -I % install -D % /out/server/%
+# Use ldd to list the dynamically linked dependencies and copy them to the output directory.
+RUN ldd /out/server | tr -s [:blank:] '\n' | grep ^/ | xargs -I % install -D % /out/%
 
 # Build the dbmigrate binary.
-RUN CGO_ENABLED=1 go build -o /out/dbmigrate/dbmigrate cmd/dbmigrate/*.go
+RUN CGO_ENABLED=1 go build -o /out/dbmigrate ./cmd/dbmigrate
 
-# Use ldd to list the dynamicly linked dependencies and copy them to the output directory.
-RUN ldd /out/dbmigrate/dbmigrate | tr -s [:blank:] '\n' | grep ^/ | xargs -I % install -D % /out/dbmigrate/%
+# Use ldd to list the dynamically linked dependencies and copy them to the output directory.
+RUN ldd /out/dbmigrate | tr -s [:blank:] '\n' | grep ^/ | xargs -I % install -D % /out/%
 
 # Stage 2. Run the binary.
 FROM scratch AS final
@@ -46,4 +46,4 @@ COPY --from=build /etc/passwd /etc/passwd
 USER househunt
 
 # Run the binary.
-ENTRYPOINT ["/out/server/server"]
+ENTRYPOINT ["./server"]

--- a/cmd/dbmigrate/main.go
+++ b/cmd/dbmigrate/main.go
@@ -32,17 +32,8 @@ func main() {
 	defer cancel()
 
 	meta := migrate.Metadata{
-		AppVersion: internal.BuildCommit,
-	}
-
-	if internal.BuildTimestamp != "" {
-		ts, err := time.Parse(time.RFC3339, internal.BuildTimestamp)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "failed to parse build timestamp: %v\n", err)
-			os.Exit(1)
-		}
-
-		meta.Timestamp = ts
+		Revision:          internal.BuildRevision,
+		RevisionTimestamp: internal.BuildRevisionTime,
 	}
 
 	migrations, err := migrate.RunFS(ctx, sqlDB, migrations.FS, meta)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 
 	"github.com/willemschots/househunt/assets"
+	"github.com/willemschots/househunt/internal"
 	"github.com/willemschots/househunt/internal/web"
 	"github.com/willemschots/househunt/internal/web/view"
 	"golang.org/x/sync/errgroup"
@@ -56,7 +57,12 @@ func run(ctx context.Context, w io.Writer) int {
 	g, gCtx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
-		logger.Info("starting http server", "addr", cfg.http.addr)
+		logger.Info("starting http server",
+			"addr", cfg.http.addr,
+			"buildRevision", internal.BuildRevision,
+			"buildRevisionTime", internal.BuildRevisionTime,
+			"buildLocalModified", internal.BuildLocalModified,
+		)
 		// ListenAndServe always returns a non-nil error,
 		// g will cancel gCtx when an error is returned, so
 		// this will also stop the other goroutine.

--- a/internal/build.go
+++ b/internal/build.go
@@ -1,6 +1,37 @@
 package internal
 
-const (
-	BuildCommit    = ""
-	BuildTimestamp = ""
+import (
+	"runtime/debug"
+	"time"
 )
+
+var (
+	BuildRevision      = "unknown"
+	BuildRevisionTime  = time.Time{}
+	BuildLocalModified = "unknown"
+)
+
+func init() {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			BuildRevision = setting.Value
+		case "vcs.time":
+			if setting.Value == "" {
+				continue
+			}
+			t, err := time.Parse(time.RFC3339, setting.Value)
+			if err != nil {
+				panic(err)
+			}
+			BuildRevisionTime = t
+		case "vcs.modified":
+			BuildLocalModified = setting.Value
+		}
+	}
+}

--- a/migrations/docs/schema.gen.sql
+++ b/migrations/docs/schema.gen.sql
@@ -1,8 +1,8 @@
 CREATE TABLE migrations (
-	sequence    INTEGER PRIMARY KEY,
-	filename    TEXT NOT NULL,
-	app_version TEXT NOT NULL,
-	timestamp   TIMESTAMP NOT NULL
+	sequence           INTEGER PRIMARY KEY,
+	filename           TEXT NOT NULL,
+	revision           TEXT NOT NULL,
+	revision_timestamp TIMESTAMP NOT NULL
 );
 CREATE TABLE users(
     id            INTEGER PRIMARY KEY,


### PR DESCRIPTION
Since Go 1.18, git revision information is accessible (if available) via the `runtime/debug` package.

This PR uses this information to populate our build data. Since I haven't done a release yet, this also slightly modifies the terminology used in the migrations table to be consistent across the app.

This PR also once again fixes the Dockerfile to actually work ;-)