### PR TITLE
4-failure-tests: failing store tests

### DIFF
--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -11,11 +11,12 @@ import (
 	"github.com/willemschots/househunt/internal/auth/db"
 	"github.com/willemschots/househunt/internal/db/testdb"
 	"github.com/willemschots/househunt/internal/email"
+	"github.com/willemschots/househunt/internal/errorz/testerr"
 )
 
 func Test_Service_RegisterAccount(t *testing.T) {
 	setup := func(t *testing.T) (*auth.Service, *errList) {
-		testDB := db.New(testdb.RunWhile(t, true), func() time.Time {
+		store := db.New(testdb.RunWhile(t, true), func() time.Time {
 			return time.Now().Round(0)
 		})
 
@@ -23,9 +24,29 @@ func Test_Service_RegisterAccount(t *testing.T) {
 			mutex: &sync.Mutex{},
 			errs:  make([]error, 0),
 		}
-		svc := auth.NewService(testDB, errs.AppendErr, time.Second)
+
+		svc := auth.NewService(store, errs.AppendErr, time.Second)
 
 		return svc, errs
+	}
+
+	setupFailingStore := func(t *testing.T, dep *testerr.FailingDep) (*auth.Service, *errList) {
+		store := &failingStore{
+			store: db.New(testdb.RunWhile(t, true), func() time.Time {
+				return time.Now().Round(0)
+			}),
+			dep: dep,
+		}
+
+		errs := &errList{
+			mutex: &sync.Mutex{},
+			errs:  make([]error, 0),
+		}
+
+		svc := auth.NewService(store, errs.AppendErr, time.Second)
+
+		return svc, errs
+
 	}
 
 	t.Run("ok, register account", func(t *testing.T) {
@@ -74,6 +95,28 @@ func Test_Service_RegisterAccount(t *testing.T) {
 
 		// TODO: Assert only a single email was send.
 	})
+
+	for _, dep := range testerr.NewFailingDeps(testerr.Err, 5) {
+		t.Run("fail, dependency fails", func(t *testing.T) {
+			svc, errs := setupFailingStore(t, &dep)
+
+			credentials := auth.Credentials{
+				Email:    emailAddress(t, "test@example.com"),
+				Password: password(t, "reallyStrongPassword1"),
+			}
+			err := svc.RegisterAccount(context.Background(), credentials)
+			if err != nil {
+				t.Fatalf("failed to register account: %v", err)
+			}
+
+			// Wait for service goroutines to finish.
+			svc.Close()
+
+			errs.assertErrorIs(t, testerr.Err)
+
+			// TODO: Assert no email was sent.
+		})
+	}
 }
 
 type errList struct {
@@ -133,4 +176,76 @@ func password(t *testing.T, raw string) auth.Password {
 	}
 
 	return p
+}
+
+// failingStore wraps a real store but fails on specific calls.
+//
+// The failure is controlled by a FailingDep. They either fail
+// on the xth call, or on the xth call and all calls after that.
+type failingStore struct {
+	store auth.Store
+	dep   *testerr.FailingDep
+}
+
+func (f *failingStore) BeginTx(ctx context.Context) (auth.Tx, error) {
+	return testerr.MaybeFail(f.dep, func() (auth.Tx, error) {
+		realTx, err := f.store.BeginTx(ctx)
+		return &failingTx{
+			store: f,
+			tx:    realTx,
+		}, err
+	})
+}
+
+type failingTx struct {
+	store *failingStore
+	tx    auth.Tx
+}
+
+func (f *failingTx) Commit() error {
+	return testerr.MaybeFailErrFunc(f.store.dep, func() error {
+		return f.tx.Commit()
+	})
+}
+
+func (f *failingTx) Rollback() error {
+	return testerr.MaybeFailErrFunc(f.store.dep, func() error {
+		return f.tx.Rollback()
+	})
+}
+
+func (f *failingTx) CreateUser(u *auth.User) error {
+	return testerr.MaybeFailErrFunc(f.store.dep, func() error {
+		return f.tx.CreateUser(u)
+	})
+}
+
+func (f *failingTx) UpdateUser(u *auth.User) error {
+	return testerr.MaybeFailErrFunc(f.store.dep, func() error {
+		return f.tx.UpdateUser(u)
+	})
+}
+
+func (f *failingTx) FindUserByEmail(v email.Address) (auth.User, error) {
+	return testerr.MaybeFail(f.store.dep, func() (auth.User, error) {
+		return f.tx.FindUserByEmail(v)
+	})
+}
+
+func (f *failingTx) CreateEmailToken(t *auth.EmailToken) error {
+	return testerr.MaybeFailErrFunc(f.store.dep, func() error {
+		return f.tx.CreateEmailToken(t)
+	})
+}
+
+func (f *failingTx) UpdateEmailToken(t *auth.EmailToken) error {
+	return testerr.MaybeFailErrFunc(f.store.dep, func() error {
+		return f.tx.UpdateEmailToken(t)
+	})
+}
+
+func (f *failingTx) FindEmailTokenByID(id int) (auth.EmailToken, error) {
+	return testerr.MaybeFail(f.store.dep, func() (auth.EmailToken, error) {
+		return f.tx.FindEmailTokenByID(id)
+	})
 }

--- a/internal/errorz/testerr/failing_dep.go
+++ b/internal/errorz/testerr/failing_dep.go
@@ -1,0 +1,64 @@
+package testerr
+
+type FailingDep struct {
+	CallIndex         int
+	Err               error
+	FailAllAfterIndex bool
+	FailAtIndex       int
+}
+
+// NewFailingDeps will create failure cases for a number of calls to a dependency.
+//
+// Dependencies will fail in two ways:
+// - A single failure, then all calls after succesful.
+// - All calls will fail after a number of succesful calls.
+func NewFailingDeps(err error, expectCalls int) []FailingDep {
+	deps := make([]FailingDep, 0, expectCalls*2)
+	for i := 0; i < expectCalls; i++ {
+		deps = append(deps, FailingDep{
+			CallIndex:         -1,
+			Err:               err,
+			FailAllAfterIndex: true,
+			FailAtIndex:       i,
+		}, FailingDep{
+			CallIndex:         -1,
+			Err:               err,
+			FailAllAfterIndex: false,
+			FailAtIndex:       i,
+		})
+	}
+
+	return deps
+}
+
+// MaybeFailErrFunc fails the call if the next value in Fails is true.
+func MaybeFailErrFunc(dep *FailingDep, f func() error) error {
+	dep.CallIndex++
+
+	if dep.FailAtIndex == dep.CallIndex {
+		return dep.Err
+	}
+
+	if dep.FailAllAfterIndex && dep.CallIndex > dep.FailAtIndex {
+		return dep.Err
+	}
+
+	return f()
+}
+
+// MaybeFail fails the call if the next value in Fails is true.
+func MaybeFail[T any](dep *FailingDep, f func() (T, error)) (T, error) {
+	dep.CallIndex++
+
+	var zero T
+
+	if dep.FailAtIndex == dep.CallIndex {
+		return zero, dep.Err
+	}
+
+	if dep.FailAllAfterIndex && dep.CallIndex > dep.FailAtIndex {
+		return zero, dep.Err
+	}
+
+	return f()
+}

--- a/internal/errorz/testerr/testerr.go
+++ b/internal/errorz/testerr/testerr.go
@@ -1,0 +1,5 @@
+package testerr
+
+import "errors"
+
+var Err = errors.New("test error")


### PR DESCRIPTION
I'm not a big fan of mocking, I find that it ties your unit tests too closely your implementation.

However, one thing that can be difficult to test entirely without test doubles is error handling.

For most "business errors" you can get your system in a state that you can tests the real thing, you don't necessarily need test doubles for these.

## Unexpected errors

However, the kind of errors that are "unexpected" and technical in nature can be difficult to test without test doubles. Imagine errors for failed connections, full storage etc.

## Injecting errors

So how do you inject these errors?

In this PR I'm aiming to test the error handling in the `auth.Service`, which uses the `auth.Store` interface. Any unexpected errors returned by the store should be reported to a pre-registered error handler.

![wireframe-listings drawio(3)(2)](https://github.com/willemschots/househunt/assets/1287926/6c062d27-b922-48d1-9716-404b962ac3ab)

To insert such unexpected errors we implement the `auth.Store` interface by wrapping a regular store. The `failingStore` can be configured to fail on the x-th call or x-th call and every call after. All good calls will be forwarded to the wrapped store.

I foresee that we will need this logic of "failing dependencies" in other packages, so I've put it in a dedicated `testerr` package.
