### PR TITLE
4: Sending emails

### DIFF
--- a/internal/auth/email_token_test.go
+++ b/internal/auth/email_token_test.go
@@ -132,9 +132,9 @@ func Test_Token_PreventExposure(t *testing.T) {
 			t.Fatalf("failed to generate token: %v", err)
 		}
 
-		buf := &bytes.Buffer{}
+		var buf bytes.Buffer
 
-		logger := slog.New(slog.NewTextHandler(buf, nil))
+		logger := slog.New(slog.NewTextHandler(&buf, nil))
 
 		logger.Info("attempting to log a password", "password", tok)
 

--- a/internal/auth/password_test.go
+++ b/internal/auth/password_test.go
@@ -127,9 +127,9 @@ func Test_Password_PreventExposure(t *testing.T) {
 	})
 
 	t.Run("ok, log output", func(t *testing.T) {
-		buf := &bytes.Buffer{}
+		var buf bytes.Buffer
 
-		logger := slog.New(slog.NewTextHandler(buf, nil))
+		logger := slog.New(slog.NewTextHandler(&buf, nil))
 
 		logger.Info("attempting to log a password", "password", pwd)
 

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -108,8 +108,12 @@ func (s *Service) createNewUser(ctx context.Context, user User) {
 	}
 
 	s.inTx(ctx, func(tx Tx) error {
+		// TODO: Limit nr of tokens per user.
+
 		_, err := tx.FindUserByEmail(user.Email)
 		if err == nil {
+			// TODO: Check if the user is active.
+			// Only return an error if the user is active.
 			return ErrDuplicateAccount
 		}
 

--- a/internal/email/log_sender.go
+++ b/internal/email/log_sender.go
@@ -1,0 +1,31 @@
+package email
+
+import (
+	"context"
+	"log/slog"
+)
+
+// LogSender is a Sender that logs the email to the logger instead of sending it.
+// Note that this is not meant for production use as it logs the email addresses
+// and all email contents. Resulting in sensitive information being logged.
+type LogSender struct {
+	logger *slog.Logger
+}
+
+// NewLogSender creates a new LogSender.
+func NewLogSender(logger *slog.Logger) *LogSender {
+	return &LogSender{
+		logger: logger,
+	}
+}
+
+// Send logs the email to the logger.
+func (s *LogSender) Send(_ context.Context, from, recipient Address, subject, body string) error {
+	s.logger.Info("send email",
+		"from", from,
+		"recipient", recipient,
+		"subject", subject,
+		"body", body,
+	)
+	return nil
+}

--- a/internal/email/mailgun/mailgun.go
+++ b/internal/email/mailgun/mailgun.go
@@ -1,0 +1,97 @@
+package mailgun
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"strings"
+
+	"github.com/willemschots/househunt/internal/email"
+)
+
+// Settings contains the settings for the Mailgun API.
+type Settings struct {
+	APIHost  string
+	Domain   string
+	Username string
+	Password string
+}
+
+// Sender is an email sender that sends emails using the Mailgun API.
+type Sender struct {
+	client   *http.Client
+	settings Settings
+}
+
+// NewSender creates a new sender.
+func NewSender(client *http.Client, s Settings) *Sender {
+	return &Sender{
+		client:   client,
+		settings: s,
+	}
+}
+
+// Send sends an email using the Mailgun API.
+func (s *Sender) Send(ctx context.Context, from, recipient email.Address, subject, body string) error {
+	// Below we send a POST request to the Mailgun API to send an email. We don't use the Go mailgun package,
+	// because it brings in a lot of dependencies that we don't need. If we need more advanced features, we can
+	// reconsider using it.
+
+	// We first map the input fields to a multipart form.
+	data := map[string]io.Reader{
+		"from":    strings.NewReader(string(from)),
+		"to":      strings.NewReader(string(recipient)),
+		"subject": strings.NewReader(subject),
+		"text":    strings.NewReader(body),
+	}
+
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+	for field, v := range data {
+		ff, err := w.CreateFormField(field)
+		if err != nil {
+			return err
+		}
+		_, err = io.Copy(ff, v)
+		if err != nil {
+			return err
+		}
+	}
+
+	err := w.Close()
+	if err != nil {
+		return err
+	}
+
+	// Then we construct the request.
+	reqURL := fmt.Sprintf("https://%s/v3/%s/messages", s.settings.APIHost, s.settings.Domain)
+	reqBody := bytes.NewReader(buf.Bytes())
+	req, err := http.NewRequest(http.MethodPost, reqURL, reqBody)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", w.FormDataContentType())
+	req.SetBasicAuth(s.settings.Username, s.settings.Password)
+
+	// And finally we send the request.
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+
+	resBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("request did not succeeed %d: %v", resp.StatusCode, string(resBody))
+	}
+
+	return nil
+}

--- a/internal/email/service.go
+++ b/internal/email/service.go
@@ -1,0 +1,41 @@
+package email
+
+import (
+	"context"
+)
+
+// TemplateElement is used by a renderer to identify the different parts of an email template.
+type TemplateElement string
+
+const (
+	ElementSubject TemplateElement = "subject"
+	ElementBody    TemplateElement = "body"
+)
+
+// Renderer is responsible for rendering email templates.
+type Renderer interface {
+	Render(ctx context.Context, name string, element TemplateElement, data any) (string, error)
+}
+
+// Sender is responsible for actually sending an email.
+type Sender interface {
+	Send(ctx context.Context, sender, recipient Address, subject, body string) error
+}
+
+// Service provides the main functionality for sending emails.
+type Service struct {
+	renderer Renderer
+	sender   Sender
+}
+
+func NewService(renderer Renderer, sender Sender) *Service {
+	return &Service{
+		renderer: renderer,
+		sender:   sender,
+	}
+}
+
+func (s *Service) SendMessage(ctx context.Context, name string, recipient Address, data any) error {
+	// TODO: Implement.
+	return nil
+}

--- a/internal/email/service.go
+++ b/internal/email/service.go
@@ -1,7 +1,9 @@
 package email
 
 import (
+	"bytes"
 	"context"
+	"io"
 )
 
 // TemplateElement is used by a renderer to identify the different parts of an email template.
@@ -14,28 +16,44 @@ const (
 
 // Renderer is responsible for rendering email templates.
 type Renderer interface {
-	Render(ctx context.Context, name string, element TemplateElement, data any) (string, error)
+	Render(w io.Writer, name string, element TemplateElement, data any) error
 }
 
 // Sender is responsible for actually sending an email.
 type Sender interface {
-	Send(ctx context.Context, sender, recipient Address, subject, body string) error
+	Send(ctx context.Context, from, recipient Address, subject, body string) error
 }
 
 // Service provides the main functionality for sending emails.
 type Service struct {
+	from     Address
 	renderer Renderer
 	sender   Sender
 }
 
-func NewService(renderer Renderer, sender Sender) *Service {
+func NewService(from Address, renderer Renderer, sender Sender) *Service {
 	return &Service{
+		from:     from,
 		renderer: renderer,
 		sender:   sender,
 	}
 }
 
-func (s *Service) SendMessage(ctx context.Context, name string, recipient Address, data any) error {
-	// TODO: Implement.
-	return nil
+func (s *Service) Send(ctx context.Context, name string, recipient Address, data any) error {
+	var (
+		sBuf bytes.Buffer
+		bBuf bytes.Buffer
+	)
+
+	err := s.renderer.Render(&sBuf, name, ElementSubject, data)
+	if err != nil {
+		return err
+	}
+
+	err = s.renderer.Render(&bBuf, name, ElementBody, data)
+	if err != nil {
+		return err
+	}
+
+	return s.sender.Send(ctx, s.from, recipient, sBuf.String(), bBuf.String())
 }

--- a/internal/email/service_test.go
+++ b/internal/email/service_test.go
@@ -1,0 +1,27 @@
+package email_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/willemschots/househunt/internal/email"
+)
+
+func Test_NewService(t *testing.T) {
+
+}
+
+func Test_SendEmail(t *testing.T) {
+}
+
+type fakeSender struct {
+	gotSender    email.Address
+	gotRecipient email.Address
+	gotSubject   string
+	gotBody      string
+	willError    error
+}
+
+func (f *fakeSender) Send(ctx context.Context, sender, recipient email.Address, subject, body string) error {
+	return nil
+}

--- a/internal/email/service_test.go
+++ b/internal/email/service_test.go
@@ -1,27 +1,50 @@
 package email_test
 
 import (
+	"bytes"
 	"context"
+	"log/slog"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/willemschots/househunt/internal/email"
+	"github.com/willemschots/househunt/internal/email/view"
 )
 
-func Test_NewService(t *testing.T) {
-
-}
-
 func Test_SendEmail(t *testing.T) {
-}
+	t.Run("ok", func(t *testing.T) {
+		renderer := view.NewFSRenderer(os.DirFS("testdata"))
 
-type fakeSender struct {
-	gotSender    email.Address
-	gotRecipient email.Address
-	gotSubject   string
-	gotBody      string
-	willError    error
-}
+		var buf bytes.Buffer
+		logger := slog.New(slog.NewTextHandler(&buf, nil))
+		sender := email.NewLogSender(logger)
 
-func (f *fakeSender) Send(ctx context.Context, sender, recipient email.Address, subject, body string) error {
-	return nil
+		svc := email.NewService(email.Address("alice@example.com"), renderer, sender)
+
+		data := struct {
+			Name    string
+			Message string
+		}{
+			Name:    "Jacob",
+			Message: "Today is a beautiful day",
+		}
+		err := svc.Send(context.Background(), "test", email.Address("jacob@example.com"), data)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		got := buf.String()
+		for _, want := range []string{
+			`msg="send email"`,
+			`from=alice@example.com`,
+			`recipient=jacob@example.com`,
+			`subject="Hello Jacob!"`,
+			`body="Your message is Today is a beautiful day"`,
+		} {
+			if !strings.Contains(got, want) {
+				t.Fatalf("want %q to contain %q", got, want)
+			}
+		}
+	})
 }

--- a/internal/email/testdata/test.tmpl
+++ b/internal/email/testdata/test.tmpl
@@ -1,0 +1,2 @@
+{{ block "subject" . }}Hello {{ .Name }}!{{ end }}
+{{ block "body" . }}Your message is {{ .Message }}{{ end }}

--- a/internal/email/view/fs_renderer.go
+++ b/internal/email/view/fs_renderer.go
@@ -1,0 +1,25 @@
+package view
+
+import (
+	"io"
+	"io/fs"
+
+	"github.com/willemschots/househunt/internal/email"
+)
+
+type FSRenderer struct {
+	fs fs.FS
+}
+
+func NewFSRenderer(fs fs.FS) *FSRenderer {
+	return &FSRenderer{fs: fs}
+}
+
+func (r *FSRenderer) Render(w io.Writer, name string, element email.TemplateElement, data any) error {
+	v, err := Parse(r.fs, name)
+	if err != nil {
+		return err
+	}
+
+	return v.Render(w, element, data)
+}

--- a/internal/email/view/view.go
+++ b/internal/email/view/view.go
@@ -1,0 +1,75 @@
+package view
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"text/template"
+
+	"github.com/willemschots/househunt/internal/email"
+)
+
+// View is a template used to render email messages.
+type View struct {
+	tmpl *template.Template
+}
+
+// Parse parses the file system and returns a view for the given name.
+// fs is expected to contain *.tmpl files in the root directory.
+func Parse(fs fs.FS, name string) (*View, error) {
+	// Validate the view name, just to be sure.
+	//
+	// Generally these will be hardcoded, but if for some reason we end
+	// up with user input as a view name, we want to error. These view names
+	// are used to construct filenames and we don't want to inadvertently
+	// allow directory traversal.
+	if err := validateName(name); err != nil {
+		return nil, err
+	}
+
+	filename := fmt.Sprintf("%s.tmpl", name)
+	tmpl, err := template.New(name).ParseFS(fs, filename)
+	if err != nil {
+		return nil, err
+	}
+
+	subjectTmpl := tmpl.Lookup(string(email.ElementSubject))
+	if subjectTmpl == nil {
+		return nil, fmt.Errorf("missing %s template", email.ElementSubject)
+	}
+
+	bodyTempl := tmpl.Lookup(string(email.ElementBody))
+	if bodyTempl == nil {
+		return nil, fmt.Errorf("missing %s template", email.ElementBody)
+	}
+
+	return &View{
+		tmpl: tmpl,
+	}, nil
+}
+
+func (v *View) Render(w io.Writer, element email.TemplateElement, data any) error {
+	if err := v.tmpl.ExecuteTemplate(w, string(element), data); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateName checks if all characters are alphanumeric, dashes or underscores.
+func validateName(name string) error {
+	for _, c := range name {
+		if !validViewRune(c) {
+			return fmt.Errorf("invalid character %v in view name: %s", c, name)
+		}
+	}
+	return nil
+}
+
+func validViewRune(r rune) bool {
+	if r == '-' || r == '_' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+		return true
+	}
+
+	return false
+}

--- a/internal/email/view/view_test.go
+++ b/internal/email/view/view_test.go
@@ -1,0 +1,171 @@
+package view_test
+
+import (
+	"bytes"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/willemschots/househunt/internal/email"
+	"github.com/willemschots/househunt/internal/email/view"
+)
+
+func Test_View_ParseAndRender(t *testing.T) {
+	okTests := map[string]struct {
+		files       map[string]string
+		parseName   string
+		renderData  any
+		wantSubject string
+		wantBody    string
+	}{
+		"ok, single template": {
+			files: map[string]string{
+				"test.tmpl": `{{ block "subject" . }}Hello world{{ end }} {{ block "body" . }}Message{{ end }}`,
+			},
+			parseName:   "test",
+			renderData:  nil,
+			wantSubject: "Hello world",
+			wantBody:    "Message",
+		},
+		"ok, multiple templates": {
+			files: map[string]string{
+				"test-1.tmpl": `{{ block "subject" . }}Hello 1{{ end }} {{ block "body" . }}Message 1{{ end }}`,
+				"test-2.tmpl": `{{ block "subject" . }}Hello 2{{ end }} {{ block "body" . }}Message 2{{ end }}`,
+				"test-3.tmpl": `{{ block "subject" . }}Hello 3{{ end }} {{ block "body" . }}Message 3{{ end }}`,
+			},
+			parseName:   "test-2",
+			renderData:  nil,
+			wantSubject: "Hello 2",
+			wantBody:    "Message 2",
+		},
+		"ok, with data": {
+			files: map[string]string{
+				"test.tmpl": `{{ block "subject" . }}Hello {{ .Name }}{{ end }} {{ block "body" . }}I'm saying {{.Message}}{{ end }}`,
+			},
+			parseName:   "test",
+			renderData:  struct{ Name, Message string }{"world", "Hi!"},
+			wantSubject: "Hello world",
+			wantBody:    "I'm saying Hi!",
+		},
+	}
+
+	for name, tc := range okTests {
+		t.Run(name, func(t *testing.T) {
+			fs := tempTestFS(t, tc.files)
+			v, err := view.Parse(fs, tc.parseName)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var buf bytes.Buffer
+			err = v.Render(&buf, email.ElementSubject, tc.renderData)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			gotSubject := buf.String()
+			if gotSubject != tc.wantSubject {
+				t.Errorf("unexpected subject: got %q, want %q", gotSubject, tc.wantSubject)
+			}
+
+			buf.Reset()
+
+			err = v.Render(&buf, email.ElementBody, tc.renderData)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			gotBody := buf.String()
+			if gotBody != tc.wantBody {
+				t.Errorf("unexpected body: got %q, want %q", gotBody, tc.wantBody)
+			}
+		})
+	}
+
+	parseFails := map[string]struct {
+		files map[string]string
+		name  string
+	}{
+		"no templates": {
+			files: map[string]string{},
+			name:  "test",
+		},
+		"no template for name": {
+			files: map[string]string{
+				"test.tmpl": `{{ block "subject" . }}Hello world{{ end }} {{ block "body" . }}Message{{ end }}`,
+			},
+			name: "other",
+		},
+		"empty template": {
+			files: map[string]string{
+				"test.tmpl": "",
+			},
+		},
+		"missing subject block": {
+			files: map[string]string{
+				"test.tmpl": `{{ block "body" . }}Message{{ end }}`,
+			},
+			name: "test",
+		},
+		"missing body block": {
+			files: map[string]string{
+				"test.tmpl": `{{ block "subject" . }}Hello world{{ end }}`,
+			},
+			name: "test",
+		},
+		"syntax error": {
+			files: map[string]string{
+				"test.tmpl": `{{ block "subject" . }}Hello world{{ end }} {{ block "body" . }}Message{{ end }`,
+			},
+			name: "test",
+		},
+		"filename with disallowed rune": {
+			files: map[string]string{
+				"#.tmpl": `{{ block "subject" . }}Hello world{{ end }} {{ block "body" . }}Message{{ end }}`,
+			},
+			name: "#",
+		},
+	}
+
+	for name, tc := range parseFails {
+		t.Run(name, func(t *testing.T) {
+			fs := tempTestFS(t, tc.files)
+			_, err := view.Parse(fs, tc.name)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+		})
+	}
+}
+
+func tempTestFS(t *testing.T, files map[string]string) fs.FS {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "househunt_email_view_test")
+	if err != nil {
+		t.Fatalf("failed to create temporary directory for views: %v", err)
+	}
+
+	t.Cleanup(func() {
+		err := os.RemoveAll(dir)
+		if err != nil {
+			t.Fatalf("failed to remove temporary directory: %v", err)
+		}
+	})
+
+	for name, content := range files {
+		fn := filepath.Join(dir, name)
+		err := os.MkdirAll(filepath.Dir(fn), 0755)
+		if err != nil {
+			t.Fatalf("failed to create path for temporary file: %v", err)
+		}
+
+		err = os.WriteFile(fn, []byte(content), 0644)
+		if err != nil {
+			t.Fatalf("failed to write temporary file: %v", err)
+		}
+	}
+
+	return os.DirFS(dir)
+}

--- a/internal/web/view/view.go
+++ b/internal/web/view/view.go
@@ -22,12 +22,14 @@ type View struct {
 }
 
 // Parse parses the file system and returns a view for the given name.
+// fs is expected to contain the specified view files in the root directory.
 func Parse(viewFS fs.FS, name string) (*View, error) {
-	// Validate the filename, just to be sure.
+	// Validate the view name, just to be sure.
 	//
 	// Generally these will be hardcoded, but if for some reason we end
-	// up with user input as a filename, we don't want to allow them
-	// access to the filesystem.
+	// up with user input as a view name, we want to error. These view names
+	// are used to construct filenames and we don't want to inadvertently
+	// allow directory traversal.
 	if err := validateName(name); err != nil {
 		return nil, err
 	}

--- a/internal/web/view/view_test.go
+++ b/internal/web/view/view_test.go
@@ -73,15 +73,15 @@ func TestView_ParseAndRender(t *testing.T) {
 
 	for name, tc := range okTests {
 		t.Run(name, func(t *testing.T) {
-			tempFS := tempFilesForTest(t, tc.files)
+			tempFS := tempTestFS(t, tc.files)
 
 			v, err := view.Parse(tempFS, tc.name)
 			if err != nil {
 				t.Fatalf("unexpected error parsing view: %v", err)
 			}
 
-			buf := &bytes.Buffer{}
-			err = v.Render(buf, tc.data)
+			var buf bytes.Buffer
+			err = v.Render(&buf, tc.data)
 			if err != nil {
 				t.Fatalf("unexpected error rendering view: %v", err)
 			}
@@ -125,7 +125,7 @@ func TestView_ParseAndRender(t *testing.T) {
 
 	for name, tc := range parseFails {
 		t.Run(name, func(t *testing.T) {
-			tempFS := tempFilesForTest(t, tc.files)
+			tempFS := tempTestFS(t, tc.files)
 
 			_, err := view.Parse(tempFS, tc.name)
 			if err == nil {
@@ -135,10 +135,10 @@ func TestView_ParseAndRender(t *testing.T) {
 	}
 }
 
-func tempFilesForTest(t *testing.T, files map[string]string) fs.FS {
+func tempTestFS(t *testing.T, files map[string]string) fs.FS {
 	t.Helper()
 
-	dir, err := os.MkdirTemp("", "househunt_view_test")
+	dir, err := os.MkdirTemp("", "househunt_web_view_test")
 	if err != nil {
 		t.Fatalf("failed to create temporary directory for views: %v", err)
 	}


### PR DESCRIPTION
To complete the authentication system, we will need to be able to send emails. This PR adds basic support for text-based email messages. Emails are created by rendering email bodies and subject lines and then passing them to a "sender".

In this PR we support two senders:
- Mailgun: Send an email via the Mailgun HTTP api.
- Logs: Send an email to your logs. Note that this is for local development only, as it could lead to logging of sensitive data.

## Notes:

- Just like with the HTML templates, I still need to implement caching.
- In the future we might also implement HTML emails, but for now I will stick with just text. We have more important tasks to continue with :)


