### PR TITLE
4-hide-sensitive-values: hide for all formatting verbs

### DIFF
--- a/internal/auth/password.go
+++ b/internal/auth/password.go
@@ -55,12 +55,8 @@ func (p Password) Hash() (Argon2Hash, error) {
 	return hashBytes(p.plain)
 }
 
-func (p Password) String() string {
-	return SecretMarker
-}
-
-func (p Password) GoString() string {
-	return SecretMarker
+func (p Password) Format(f fmt.State, verb rune) {
+	f.Write([]byte(SecretMarker))
 }
 
 func (p Password) MarshalText() ([]byte, error) {

--- a/internal/auth/password_test.go
+++ b/internal/auth/password_test.go
@@ -111,8 +111,8 @@ func Test_Password_PreventExposure(t *testing.T) {
 	}
 
 	t.Run("ok, fmt", func(t *testing.T) {
-		assert(t, pwd.String())
 		assert(t, fmt.Sprintf("%s", pwd)) //nolint:gosimple
+		assert(t, fmt.Sprintf("%d", pwd))
 		assert(t, fmt.Sprintf("%v", pwd))
 		assert(t, fmt.Sprintf("%#v", pwd))
 	})


### PR DESCRIPTION
This PR ensures the password outputs the secret marker for all formatting verbs.