### PR TITLE
4-field-level-encryption: add encryptor

### DIFF
--- a/internal/krypto/encryptor.go
+++ b/internal/krypto/encryptor.go
@@ -1,0 +1,115 @@
+package krypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/binary"
+	"errors"
+)
+
+var (
+	// ErrUnknownKey indicates that the key used to encrypt the data is unknown.
+	ErrUnknownKey = errors.New("unknown key")
+	// ErrInvalidData indicates that the data is invalid.
+	ErrInvalidData = errors.New("invalid data")
+)
+
+const indexBytes = 4
+
+// Encryptor encrypts and decrypts data using AES-GCM.
+//
+// The encryptor uses an append only list of keys for encryption and decryption.
+// The last key in the list is considered the latest key.
+//
+// To construct output data, the encryptor prefixes the encrypted data with the index
+// of the used key. This allows the encryptor to work with multiple keys and to decrypt
+// data encrypted with an older key.
+//
+// The index used is not considered secret.
+type Encryptor struct {
+	keys []Key
+}
+
+// NewEncryptor creates a new encryptor with the provided keys.
+func NewEncryptor(keys []Key) (*Encryptor, error) {
+	if len(keys) == 0 {
+		return nil, errors.New("at least one key is required")
+	}
+
+	return &Encryptor{
+		keys: keys,
+	}, nil
+}
+
+// Encrypt encrypts the data using the latest available key.
+// It returns the encrypted data prefixed with the key identifier.
+func (s *Encryptor) Encrypt(data []byte) ([]byte, error) {
+	if len(data) == 0 {
+		return nil, ErrInvalidData
+	}
+
+	index := len(s.keys) - 1
+	block, err := aes.NewCipher(s.keys[index].value)
+	if err != nil {
+		return nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	nonce, err := randBytes(gcm.NonceSize())
+	if err != nil {
+		return nil, err
+	}
+
+	buf := make([]byte, indexBytes)
+	binary.BigEndian.PutUint32(buf, uint32(index))
+
+	result := gcm.Seal(nil, nonce, data, buf)
+	buf = append(buf, nonce...)
+	buf = append(buf, result...)
+	return buf, nil
+}
+
+// Decrypt decrypts the data using the key identified by the first 4 bytes in the data.
+// It returns the decrypted data or an error.
+func (s *Encryptor) Decrypt(message []byte) ([]byte, error) {
+	if len(message) < indexBytes {
+		return nil, ErrInvalidData
+	}
+
+	index := binary.BigEndian.Uint32(message[:indexBytes])
+	if int(index) >= len(s.keys) {
+		return nil, ErrUnknownKey
+	}
+
+	block, err := aes.NewCipher(s.keys[index].value)
+	if err != nil {
+		return nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	nonceSize := gcm.NonceSize()
+	minLen := indexBytes + nonceSize
+	if len(message) <= minLen {
+		return nil, ErrInvalidData
+	}
+
+	nonce := message[indexBytes:minLen]
+	ciphertext := message[minLen:]
+
+	return gcm.Open(nil, nonce, ciphertext, message[:4])
+}
+
+func randBytes(n int) ([]byte, error) {
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+	return b, err
+}

--- a/internal/krypto/encryptor_test.go
+++ b/internal/krypto/encryptor_test.go
@@ -1,0 +1,192 @@
+package krypto_test
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/willemschots/househunt/internal/krypto"
+)
+
+func Test_NewEncryptor(t *testing.T) {
+	t.Run("fail, no keys", func(t *testing.T) {
+		_, err := krypto.NewEncryptor(nil)
+		if err == nil {
+			t.Fatalf("wanted error, got <nil>")
+		}
+	})
+}
+
+func Test_Encryptor_EncryptAndDecrypt(t *testing.T) {
+	okCases := map[string][]byte{
+		"ok, minimum input": {0},
+		"ok, typical input": []byte("my secret message"),
+	}
+
+	for name, raw := range okCases {
+		t.Run(name, func(t *testing.T) {
+			svc := must(krypto.NewEncryptor([]krypto.Key{
+				must(krypto.ParseKey("2b671594b775f371eab4050b4d58326682df6b1a6cc2e886717b1a26b4d6c45d")),
+			}))
+
+			result, err := svc.Encrypt([]byte(raw))
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			decrypted, err := svc.Decrypt(result)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !bytes.Equal(decrypted, raw) {
+				t.Fatalf("want %q, got %q", raw, decrypted)
+			}
+		})
+	}
+
+	invalidEncrypt := map[string][]byte{
+		"nil":         nil,
+		"empty slice": {},
+	}
+
+	for name, raw := range invalidEncrypt {
+		t.Run(name, func(t *testing.T) {
+			enc := must(krypto.NewEncryptor([]krypto.Key{
+				must(krypto.ParseKey("2b671594b775f371eab4050b4d58326682df6b1a6cc2e886717b1a26b4d6c45d")),
+			}))
+
+			_, err := enc.Encrypt(raw)
+			if !errors.Is(err, krypto.ErrInvalidData) {
+				t.Fatalf("wanted error %v, got %v (via errors.Is)", krypto.ErrInvalidData, err)
+			}
+		})
+	}
+
+	t.Run("ok, multiple keys", func(t *testing.T) {
+		enc := must(krypto.NewEncryptor([]krypto.Key{
+			must(krypto.ParseKey("2b671594b775f371eab4050b4d58326682df6b1a6cc2e886717b1a26b4d6c45d")),
+			must(krypto.ParseKey("90303dfed7994260ea4817a5ca8a392915cd401115b2f97495dadfcbcd14adbf")),
+		}))
+
+		raw := "my secret message"
+		result, err := enc.Encrypt([]byte(raw))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		decrypted, err := enc.Decrypt(result)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if string(decrypted) != raw {
+			t.Fatalf("want %q, got %q", raw, decrypted)
+		}
+	})
+
+	t.Run("ok, decrypt with older key", func(t *testing.T) {
+		keys := []krypto.Key{
+			must(krypto.ParseKey("2b671594b775f371eab4050b4d58326682df6b1a6cc2e886717b1a26b4d6c45d")),
+			must(krypto.ParseKey("90303dfed7994260ea4817a5ca8a392915cd401115b2f97495dadfcbcd14adbf")),
+		}
+
+		// old encryptor only has the first key.
+		encOld := must(krypto.NewEncryptor(keys[:1]))
+
+		raw := "my secret message"
+		result, err := encOld.Encrypt([]byte(raw))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// new encryptor has both keys but should use the old key to decrypt.
+		encNew := must(krypto.NewEncryptor(keys))
+
+		decrypted, err := encNew.Decrypt(result)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if string(decrypted) != raw {
+			t.Fatalf("want %q, got %q", raw, decrypted)
+		}
+	})
+
+	t.Run("fail, no key for this index", func(t *testing.T) {
+		keys := []krypto.Key{
+			must(krypto.ParseKey("2b671594b775f371eab4050b4d58326682df6b1a6cc2e886717b1a26b4d6c45d")),
+			must(krypto.ParseKey("90303dfed7994260ea4817a5ca8a392915cd401115b2f97495dadfcbcd14adbf")),
+		}
+
+		encOld := must(krypto.NewEncryptor(keys))
+		encNew := must(krypto.NewEncryptor(keys[0:1])) // new encryptor only has the first key.
+
+		raw := "my secret message"
+		result, err := encOld.Encrypt([]byte(raw))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		_, err = encNew.Decrypt(result)
+		if !errors.Is(err, krypto.ErrUnknownKey) {
+			t.Fatalf("wanted error %v, got %v (via errors.Is)", krypto.ErrUnknownKey, err)
+		}
+	})
+
+	t.Run("fail, key was changed", func(t *testing.T) {
+		keys := []krypto.Key{
+			must(krypto.ParseKey("2b671594b775f371eab4050b4d58326682df6b1a6cc2e886717b1a26b4d6c45d")),
+			must(krypto.ParseKey("90303dfed7994260ea4817a5ca8a392915cd401115b2f97495dadfcbcd14adbf")),
+		}
+
+		encOld := must(krypto.NewEncryptor(keys[:1]))
+		encNew := must(krypto.NewEncryptor(keys[1:])) // both use a different key.
+
+		raw := "my secret message"
+		result, err := encOld.Encrypt([]byte(raw))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		_, err = encNew.Decrypt(result)
+		if err == nil {
+			t.Fatalf("wanted error, got <nil>")
+		}
+	})
+
+	invalidDecrypt := map[string][]byte{
+		"nil":            nil,
+		"empty slice":    {},
+		"short of index": {0, 0, 0},
+		"only index":     {0, 0, 0, 0},
+		"short of nonce": {
+			0, 0, 0, 0, 1, 1, 1, 1,
+			1, 1, 1, 1, 1, 1, 1,
+		},
+		"only index and nonce": {
+			0, 0, 0, 0, 1, 1, 1, 1,
+			1, 1, 1, 1, 1, 1, 1, 1,
+		},
+	}
+
+	for name, msg := range invalidDecrypt {
+		t.Run(name, func(t *testing.T) {
+			svc := must(krypto.NewEncryptor([]krypto.Key{
+				must(krypto.ParseKey("2b671594b775f371eab4050b4d58326682df6b1a6cc2e886717b1a26b4d6c45d")),
+			}))
+
+			_, err := svc.Decrypt(msg)
+			if !errors.Is(err, krypto.ErrInvalidData) {
+				t.Fatalf("wanted error %v, got %v (via errors.Is)", krypto.ErrInvalidData, err)
+			}
+		})
+	}
+}
+
+func must[T any](t T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return t
+}

--- a/internal/krypto/key.go
+++ b/internal/krypto/key.go
@@ -1,0 +1,48 @@
+package krypto
+
+import (
+	"encoding/hex"
+	"errors"
+	"fmt"
+)
+
+const (
+	keyLen = 32
+
+	// SecretMarker is a string we can look for in logs to see if the app
+	// is accidentally exposing secrets.
+	SecretMarker = "<!SECRET_REDACTED!>"
+)
+
+var (
+	ErrInvalidKey = errors.New("invalid key")
+)
+
+type Key struct {
+	value []byte
+}
+
+// ParseKey expects a hex encoded key of 32 bytes (64 bytes as hex).
+func ParseKey(raw string) (Key, error) {
+	if len(raw) != keyLen*2 {
+		return Key{}, ErrInvalidKey
+	}
+
+	k := make([]byte, keyLen)
+	_, err := hex.Decode(k, []byte(raw))
+	if err != nil {
+		return Key{}, ErrInvalidKey
+	}
+
+	return Key{
+		value: k,
+	}, nil
+}
+
+func (k Key) Format(f fmt.State, verb rune) {
+	f.Write([]byte(SecretMarker))
+}
+
+func (k Key) MarshalText() ([]byte, error) {
+	return []byte(SecretMarker), nil
+}

--- a/internal/krypto/key_test.go
+++ b/internal/krypto/key_test.go
@@ -1,0 +1,81 @@
+package krypto_test
+
+import (
+	"bytes"
+	"fmt"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/willemschots/househunt/internal/krypto"
+)
+
+func Test_ParseKey(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		_, err := krypto.ParseKey("2b671594b775f371eab4050b4d58326682df6b1a6cc2e886717b1a26b4d6c45d")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	failCases := map[string]string{
+		"empty string":          "",
+		"too short":             "2b671594b775f371eab4050b4d58326682df6b1a6cc2e886717b1a26b4d6c45",
+		"too long":              "2b671594b775f371eab4050b4d58326682df6b1a6cc2e886717b1a26b4d6c45da",
+		"invalid hex character": "zb671594b775f371eab4050b4d58326682df6b1a6cc2e886717b1a26b4d6c45d",
+	}
+
+	for name, val := range failCases {
+		t.Run(name, func(t *testing.T) {
+			_, err := krypto.ParseKey(val)
+			if err == nil {
+				t.Fatalf("wanted error, got <nil>")
+			}
+		})
+	}
+}
+
+func Test_Key_PreventExposure(t *testing.T) {
+	raw := "2b671594b775f371eab4050b4d58326682df6b1a6cc2e886717b1a26b4d6c45d"
+	key := must(krypto.ParseKey(raw))
+
+	assert := func(t *testing.T, s string) {
+		t.Helper()
+		if s != krypto.SecretMarker {
+			t.Errorf("wanted\n%s\ngot\n%s\n", krypto.SecretMarker, s)
+		}
+	}
+
+	t.Run("ok, fmt", func(t *testing.T) {
+		assert(t, fmt.Sprintf("%s", key)) //nolint:gosimple
+		assert(t, fmt.Sprintf("%d", key))
+		assert(t, fmt.Sprintf("%v", key))
+		assert(t, fmt.Sprintf("%#v", key))
+	})
+
+	t.Run("ok, marshal as text", func(t *testing.T) {
+		b, err := key.MarshalText()
+		if err != nil {
+			t.Fatalf("failed to marshal as text: %v", err)
+		}
+
+		assert(t, string(b))
+	})
+
+	t.Run("ok, log output", func(t *testing.T) {
+		var buf bytes.Buffer
+
+		logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+		logger.Info("attempting to log a key", "key", key)
+
+		s := buf.String()
+		if !strings.Contains(s, krypto.SecretMarker) {
+			t.Errorf("log output\n%s\ndoes not contain secret marker: %s", s, krypto.SecretMarker)
+		}
+
+		if strings.Contains(s, raw) {
+			t.Errorf("log output\n%s\ncontains raw key: %s", s, raw)
+		}
+	})
+}


### PR DESCRIPTION
Before we can add field level encryption we need a way to securely encrypt and decrypt data.

This PR adds the `krypto.Encryptor` type which uses `AES-GCM` to encrypt and decrypt data. The encryptor can support multiple keys and embeds the index of the used key in the output message. This way it can decrypt the data using the right key and it will allow us to rotate keys if we need to.

---

P.S. You might be wondering why I use package names like `errorz` and `krypto`.

This is because there are standard library packages named `errors` and `crypto`. Using the same names would require us to alias either our own or the standard library package when we import both. If you have to alias in multiple packages that's another thing to keep consistent, so I prefer using these slightly strange names that don't conflict.