### PR TITLE
4-refactor: encrypt email addreses and search using blind index

### DIFF
--- a/internal/auth/db/queries.go
+++ b/internal/auth/db/queries.go
@@ -1,0 +1,308 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/willemschots/househunt/internal/auth"
+	"github.com/willemschots/househunt/internal/db"
+	"github.com/willemschots/househunt/internal/email"
+	"github.com/willemschots/househunt/internal/errorz"
+)
+
+type execFunc func(query string, params ...any) (sql.Result, error)
+type queryFunc func(query string, params ...any) (*sql.Rows, error)
+
+func insertUser(q db.Query, ef execFunc, u *auth.User) error {
+	if u.ID != 0 {
+		return fmt.Errorf("user already has an ID: %w", errorz.ErrConstraintViolated)
+	}
+
+	q.Unsafe(`INSERT INTO users (email_encrypted, email_blind_index, password_hash, is_active, created_at, updated_at) VALUES (`)
+	q.ParamEncrypted([]byte(u.Email))
+	q.Unsafe(`, `)
+	q.ParamBlindIndex([]byte(u.Email))
+	q.Unsafe(`, `)
+	q.Params(u.PasswordHash.String(), u.IsActive, u.CreatedAt, u.UpdatedAt)
+	q.Unsafe(`) RETURNING id`)
+
+	s, params, err := q.Get()
+	if err != nil {
+		return err
+	}
+
+	result, err := ef(s, params...)
+	if err != nil {
+		return errorz.MapDBErr(err)
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		return err
+	}
+
+	u.ID = int(id)
+
+	return nil
+}
+
+func updateUser(q db.Query, ef execFunc, u *auth.User) error {
+	q.Unsafe(`UPDATE users SET `)
+
+	q.Unsafe(`email_encrypted = `)
+	q.ParamEncrypted([]byte(u.Email))
+
+	q.Unsafe(`, email_blind_index = `)
+	q.ParamBlindIndex([]byte(u.Email))
+
+	q.Unsafe(`, password_hash = `)
+	q.Param(u.PasswordHash.String())
+
+	q.Unsafe(`, is_active = `)
+	q.Param(u.IsActive)
+
+	q.Unsafe(`, created_at = `)
+	q.Param(u.CreatedAt)
+
+	q.Unsafe(`, updated_at = `)
+	q.Param(u.UpdatedAt)
+
+	q.Unsafe(` WHERE id = `)
+	q.Params(u.ID)
+
+	s, params, err := q.Get()
+	if err != nil {
+		return err
+	}
+
+	result, err := ef(s, params...)
+	if err != nil {
+		return errorz.MapDBErr(err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return errorz.MapDBErr(err)
+	}
+
+	if rows == 0 {
+		return fmt.Errorf("user not found: %w", errorz.ErrNotFound)
+	}
+
+	return nil
+}
+
+func selectUsers(q db.Query, qf queryFunc, f *auth.UserFilter) ([]auth.User, error) {
+	q.Unsafe(`SELECT id, email_encrypted, password_hash, is_active, created_at, updated_at FROM users WHERE 1=1 `)
+
+	if len(f.IDs) > 0 {
+		q.Unsafe(`AND id IN (`)
+		q.Params(anySlice(f.IDs)...)
+		q.Unsafe(`)`)
+	}
+
+	if len(f.Emails) > 0 {
+		q.Unsafe(`AND email_blind_index IN (`)
+		for i, email := range f.Emails {
+			if i > 0 {
+				q.Unsafe(`, `)
+			}
+			q.ParamBlindIndex([]byte(email))
+		}
+		q.Unsafe(`)`)
+	}
+
+	if f.IsActive != nil {
+		q.Unsafe("AND is_active = ")
+		q.Param(f.IsActive)
+	}
+
+	q.Unsafe(` ORDER BY id ASC`)
+
+	s, params, err := q.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := qf(s, params...)
+	if err != nil {
+		return nil, errorz.MapDBErr(err)
+	}
+
+	defer rows.Close()
+
+	out := make([]auth.User, 0)
+	for rows.Next() {
+		var u auth.User
+		emailBytes := q.DecryptionTarget()
+		err := rows.Scan(&u.ID, emailBytes, &u.PasswordHash, &u.IsActive, &u.CreatedAt, &u.UpdatedAt)
+		if err != nil {
+			return nil, errorz.MapDBErr(err)
+		}
+
+		u.Email, err = email.ParseAddress(string(emailBytes.Data))
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, u)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, errorz.MapDBErr(err)
+	}
+
+	return out, nil
+}
+
+func insertEmailToken(q db.Query, ef execFunc, tok *auth.EmailToken) error {
+	if tok.ID != 0 {
+		return fmt.Errorf("email token already has an ID: %w", errorz.ErrConstraintViolated)
+	}
+
+	q.Unsafe(`INSERT INTO email_tokens (token_hash, user_id, email_encrypted, purpose, created_at, consumed_at) VALUES (`)
+	q.Params(tok.TokenHash.String(), tok.UserID)
+	q.Unsafe(`, `)
+	q.ParamEncrypted([]byte(tok.Email))
+	q.Unsafe(`, `)
+	q.Params(tok.Purpose, tok.CreatedAt, tok.ConsumedAt)
+	q.Unsafe(`) RETURNING id`)
+
+	s, params, err := q.Get()
+	if err != nil {
+		return err
+	}
+
+	result, err := ef(s, params...)
+	if err != nil {
+		return errorz.MapDBErr(err)
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		return err
+	}
+
+	tok.ID = int(id)
+
+	return nil
+}
+
+func updateEmailToken(q db.Query, ef execFunc, tok *auth.EmailToken) error {
+	q.Unsafe(`UPDATE email_tokens SET `)
+
+	q.Unsafe(`token_hash = `)
+	q.Param(tok.TokenHash.String())
+
+	q.Unsafe(`, user_id = `)
+	q.Param(tok.UserID)
+
+	q.Unsafe(`, email_encrypted = `)
+	q.ParamEncrypted([]byte(tok.Email))
+
+	q.Unsafe(`, purpose = `)
+	q.Param(tok.Purpose)
+
+	q.Unsafe(`, created_at = `)
+	q.Param(tok.CreatedAt)
+
+	q.Unsafe(`, consumed_at = `)
+	q.Param(tok.ConsumedAt)
+
+	q.Unsafe(` WHERE id = `)
+	q.Params(tok.ID)
+
+	s, params, err := q.Get()
+	if err != nil {
+		return err
+	}
+
+	result, err := ef(s, params...)
+	if err != nil {
+		return errorz.MapDBErr(err)
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return errorz.MapDBErr(err)
+	}
+
+	if rows == 0 {
+		return fmt.Errorf("email token not found: %w", errorz.ErrNotFound)
+	}
+
+	return nil
+}
+
+func selectEmailTokens(q db.Query, qf queryFunc, f *auth.EmailTokenFilter) ([]auth.EmailToken, error) {
+	q.Unsafe(`SELECT id, token_hash, user_id, email_encrypted, purpose, created_at, consumed_at FROM email_tokens WHERE 1=1 `)
+
+	if len(f.IDs) > 0 {
+		q.Unsafe(`AND id IN (`)
+		q.Params(anySlice(f.IDs)...)
+		q.Unsafe(`) `)
+	}
+
+	if len(f.UserIDs) > 0 {
+		q.Unsafe(`AND user_id IN (`)
+		q.Params(anySlice(f.UserIDs)...)
+		q.Unsafe(`) `)
+	}
+
+	if len(f.Purposes) > 0 {
+		q.Unsafe(`AND purpose IN (`)
+		q.Params(anySlice(f.Purposes)...)
+		q.Unsafe(`) `)
+	}
+
+	if f.IsConsumed != nil {
+		q.Unsafe("AND consumed_at IS ")
+		if *f.IsConsumed {
+			q.Unsafe("NOT ")
+		}
+		q.Unsafe("NULL ")
+	}
+
+	s, params, err := q.Get()
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := qf(s, params...)
+	if err != nil {
+		return nil, errorz.MapDBErr(err)
+	}
+
+	defer rows.Close()
+
+	out := make([]auth.EmailToken, 0)
+	for rows.Next() {
+		var token auth.EmailToken
+		emailBytes := q.DecryptionTarget()
+		err := rows.Scan(&token.ID, &token.TokenHash, &token.UserID, emailBytes, &token.Purpose, &token.CreatedAt, &token.ConsumedAt)
+		if err != nil {
+			return nil, errorz.MapDBErr(err)
+		}
+
+		token.Email, err = email.ParseAddress(string(emailBytes.Data))
+		if err != nil {
+			return nil, err
+		}
+
+		out = append(out, token)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, errorz.MapDBErr(err)
+	}
+
+	return out, nil
+}
+
+func anySlice[T any](s []T) []any {
+	out := make([]any, 0, len(s))
+	for _, v := range s {
+		out = append(out, v)
+	}
+	return out
+}

--- a/internal/auth/db/store.go
+++ b/internal/auth/db/store.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/willemschots/househunt/internal/auth"
+	"github.com/willemschots/househunt/internal/krypto"
 )
 
 // NowFunc is a function that returns the current time.
@@ -13,13 +14,17 @@ type NowFunc func() time.Time
 
 // Store is responsible for interacting with a database.
 type Store struct {
-	db *sql.DB
+	db            *sql.DB
+	encryptor     *krypto.Encryptor
+	blindIndexKey krypto.Key
 }
 
 // New creates a new Store.
-func New(db *sql.DB) *Store {
+func New(db *sql.DB, encryptor *krypto.Encryptor, blindIndexKey krypto.Key) *Store {
 	return &Store{
-		db: db,
+		db:            db,
+		encryptor:     encryptor,
+		blindIndexKey: blindIndexKey,
 	}
 }
 
@@ -30,6 +35,7 @@ func (s *Store) BeginTx(ctx context.Context) (auth.Tx, error) {
 		return nil, err
 	}
 	return &Tx{
-		tx: tx,
+		tx:    tx,
+		store: s,
 	}, nil
 }

--- a/internal/auth/db/store_test.go
+++ b/internal/auth/db/store_test.go
@@ -578,8 +578,13 @@ func now(t *testing.T, i int) time.Time {
 func storeForTest(t *testing.T) *db.Store {
 	t.Helper()
 
+	encryptor := must(krypto.NewEncryptor([]krypto.Key{
+		must(krypto.ParseKey("2b671594b775f371eab4050b4d58326682df6b1a6cc2e886717b1a26b4d6c45d")),
+	}))
+	indexKey := must(krypto.ParseKey("90303dfed7994260ea4817a5ca8a392915cd401115b2f97495dadfcbcd14adbf"))
+
 	testDB := testdb.RunWhile(t, true)
-	return db.New(testDB)
+	return db.New(testDB, encryptor, indexKey)
 }
 
 func newUser(t *testing.T, modFunc func(*auth.User)) auth.User {

--- a/internal/auth/db/tx.go
+++ b/internal/auth/db/tx.go
@@ -2,15 +2,21 @@ package db
 
 import (
 	"database/sql"
-	"fmt"
 
 	"github.com/willemschots/househunt/internal/auth"
 	"github.com/willemschots/househunt/internal/db"
-	"github.com/willemschots/househunt/internal/errorz"
 )
 
 type Tx struct {
-	tx *sql.Tx
+	tx    *sql.Tx
+	store *Store
+}
+
+func (t *Tx) newQuery() db.Query {
+	return db.Query{
+		Encryptor:     t.store.encryptor,
+		BlindIndexKey: t.store.blindIndexKey,
+	}
 }
 
 func (t *Tx) Commit() error {
@@ -24,126 +30,26 @@ func (t *Tx) Rollback() error {
 // CreateUser creates a user in the database.
 // It updates the users ID, CreatedAt and UpdatedAt fields when successful.
 func (t *Tx) CreateUser(u *auth.User) error {
-	if u.ID != 0 {
-		return fmt.Errorf("user already has an ID: %w", errorz.ErrConstraintViolated)
-	}
-
-	const q = `INSERT INTO users (email, password_hash, is_active, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`
-	result, err := t.tx.Exec(q, u.Email, u.PasswordHash.String(), u.IsActive, u.CreatedAt, u.UpdatedAt)
-	if err != nil {
-		return errorz.MapDBErr(err)
-	}
-
-	id, err := result.LastInsertId()
-	if err != nil {
-		return err
-	}
-
-	// Only set the fields after the query was executed.
-	u.ID = int(id)
-
-	return nil
+	return insertUser(t.newQuery(), t.tx.Exec, u)
 }
 
 // UpdateUser updates a user in the database.
 // It updates the users UpdatedAt field when successful.
 // It returns errorz.ErrNotFound if no user is found.
 func (t *Tx) UpdateUser(u *auth.User) error {
-	const q = `UPDATE users SET email = ?, password_hash = ?, is_active = ?, created_at = ?, updated_at = ? WHERE id = ?`
-	result, err := t.tx.Exec(q, u.Email, u.PasswordHash.String(), u.IsActive, u.CreatedAt, u.UpdatedAt, u.ID)
-	if err != nil {
-		return errorz.MapDBErr(err)
-	}
-
-	n, err := result.RowsAffected()
-	if err != nil {
-		return err
-	}
-
-	if n != 1 {
-		return fmt.Errorf("failed to update user %d: %w", u.ID, errorz.ErrNotFound)
-	}
-
-	return nil
+	return updateUser(t.newQuery(), t.tx.Exec, u)
 }
 
 // FindUsers queries for users based on the provided filter.
 // It returns an empty slice if no users are found.
 func (t *Tx) FindUsers(filter *auth.UserFilter) ([]auth.User, error) {
-	q, params := userFilterQuery(filter)
-	rows, err := t.tx.Query(q, params...)
-	if err != nil {
-		return nil, errorz.MapDBErr(err)
-	}
-
-	defer rows.Close()
-
-	out := make([]auth.User, 0)
-	for rows.Next() {
-		var u auth.User
-		err := rows.Scan(&u.ID, &u.Email, &u.PasswordHash, &u.IsActive, &u.CreatedAt, &u.UpdatedAt)
-		if err != nil {
-			return nil, errorz.MapDBErr(err)
-		}
-
-		out = append(out, u)
-	}
-
-	if err := rows.Err(); err != nil {
-		return nil, errorz.MapDBErr(err)
-	}
-
-	return out, nil
-}
-
-func userFilterQuery(f *auth.UserFilter) (string, []any) {
-	var q db.Query
-
-	q.Query(`SELECT id, email, password_hash, is_active, created_at, updated_at FROM users WHERE 1=1 `)
-
-	if len(f.IDs) > 0 {
-		q.Query(`AND id IN (`)
-		q.Params(anySlice(f.IDs)...)
-		q.Query(`)`)
-	}
-
-	if len(f.Emails) > 0 {
-		q.Query(`AND email IN (`)
-		q.Params(anySlice(f.Emails)...)
-		q.Query(`)`)
-	}
-
-	if f.IsActive != nil {
-		q.Query("AND is_active = ")
-		q.Param(f.IsActive)
-	}
-
-	q.Query(` ORDER BY id ASC`)
-
-	return q.Get()
+	return selectUsers(t.newQuery(), t.tx.Query, filter)
 }
 
 // CreateEmailToken creates an email token in the database.
 // It updates the token ID and CreatedAt when successful.
 func (t *Tx) CreateEmailToken(tok *auth.EmailToken) error {
-	if tok.ID != 0 {
-		return fmt.Errorf("email token already has an ID: %w", errorz.ErrConstraintViolated)
-	}
-
-	const q = `INSERT INTO email_tokens (token_hash, user_id, email, purpose, created_at, consumed_at) VALUES (?, ?, ?, ?, ?, ?)`
-	result, err := t.tx.Exec(q, tok.TokenHash.String(), tok.UserID, tok.Email, tok.Purpose, tok.CreatedAt, tok.ConsumedAt)
-	if err != nil {
-		return errorz.MapDBErr(err)
-	}
-
-	id, err := result.LastInsertId()
-	if err != nil {
-		return err
-	}
-
-	tok.ID = int(id)
-
-	return nil
+	return insertEmailToken(t.newQuery(), t.tx.Exec, tok)
 }
 
 // UpdateEmailToken updates an email token in the database.
@@ -151,90 +57,10 @@ func (t *Tx) CreateEmailToken(tok *auth.EmailToken) error {
 // It only allows updating the ConsumedAt field, attempting to
 // update any other field will return errorz.ErrConstraintViolated.
 func (t *Tx) UpdateEmailToken(tok *auth.EmailToken) error {
-	const q = `UPDATE email_tokens SET token_hash = ?, user_id = ?, email = ?, purpose = ?, created_at = ?, consumed_at = ? WHERE id = ?`
-	result, err := t.tx.Exec(q, tok.TokenHash.String(), tok.UserID, tok.Email, tok.Purpose, tok.CreatedAt, tok.ConsumedAt, tok.ID)
-	if err != nil {
-		return errorz.MapDBErr(err)
-	}
-
-	n, err := result.RowsAffected()
-	if err != nil {
-		return err
-	}
-
-	if n != 1 {
-		return fmt.Errorf("failed to update email token %d: %w", tok.ID, errorz.ErrNotFound)
-	}
-
-	return nil
+	return updateEmailToken(t.newQuery(), t.tx.Exec, tok)
 }
 
 // FindEmailTokens queries for email tokens based on the provided filter.
 func (t *Tx) FindEmailTokens(filter *auth.EmailTokenFilter) ([]auth.EmailToken, error) {
-	q, params := emailTokenFilterQuery(filter)
-	rows, err := t.tx.Query(q, params...)
-	if err != nil {
-		return nil, errorz.MapDBErr(err)
-	}
-
-	defer rows.Close()
-
-	out := make([]auth.EmailToken, 0)
-	for rows.Next() {
-		var token auth.EmailToken
-		err := rows.Scan(&token.ID, &token.TokenHash, &token.UserID, &token.Email, &token.Purpose, &token.CreatedAt, &token.ConsumedAt)
-		if err != nil {
-			return nil, errorz.MapDBErr(err)
-		}
-
-		out = append(out, token)
-	}
-
-	if err := rows.Err(); err != nil {
-		return nil, errorz.MapDBErr(err)
-	}
-
-	return out, nil
-}
-
-func emailTokenFilterQuery(f *auth.EmailTokenFilter) (string, []any) {
-	var q db.Query
-
-	q.Query(`SELECT id, token_hash, user_id, email, purpose, created_at, consumed_at FROM email_tokens WHERE 1=1 `)
-
-	if len(f.IDs) > 0 {
-		q.Query(`AND id IN (`)
-		q.Params(anySlice(f.IDs)...)
-		q.Query(`) `)
-	}
-
-	if len(f.UserIDs) > 0 {
-		q.Query(`AND user_id IN (`)
-		q.Params(anySlice(f.UserIDs)...)
-		q.Query(`) `)
-	}
-
-	if len(f.Purposes) > 0 {
-		q.Query(`AND purpose IN (`)
-		q.Params(anySlice(f.Purposes)...)
-		q.Query(`) `)
-	}
-
-	if f.IsConsumed != nil {
-		q.Query("AND consumed_at IS ")
-		if *f.IsConsumed {
-			q.Query("NOT ")
-		}
-		q.Query("NULL ")
-	}
-
-	return q.Get()
-}
-
-func anySlice[T any](s []T) []any {
-	out := make([]any, 0, len(s))
-	for _, v := range s {
-		out = append(out, v)
-	}
-	return out
+	return selectEmailTokens(t.newQuery(), t.tx.Query, filter)
 }

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -385,9 +385,15 @@ type svcDeps struct {
 }
 
 func setupService(t *testing.T, cfgFunc func(*auth.ServiceConfig)) (*auth.Service, *svcDeps) {
+	encryptor := must(krypto.NewEncryptor([]krypto.Key{
+		must(krypto.ParseKey("2b671594b775f371eab4050b4d58326682df6b1a6cc2e886717b1a26b4d6c45d")),
+	}))
+
+	indexKey := must(krypto.ParseKey("90303dfed7994260ea4817a5ca8a392915cd401115b2f97495dadfcbcd14adbf"))
+
 	deps := &svcDeps{
 		store: &testStore{
-			store:   db.New(testdb.RunWhile(t, true)),
+			store:   db.New(testdb.RunWhile(t, true), encryptor, indexKey),
 			tracker: &testerr.Calltracker{}, // empty call trackers never fail.
 		},
 		errList: &errList{

--- a/internal/db/query.go
+++ b/internal/db/query.go
@@ -1,6 +1,11 @@
 package db
 
-import "strings"
+import (
+	"errors"
+	"strings"
+
+	"github.com/willemschots/househunt/internal/krypto"
+)
 
 // Query helps build SQL queries using bind parameters.
 // Use Query to construct parts of a query and use Param to add bind parameters.
@@ -8,12 +13,15 @@ import "strings"
 //
 // The zero value is ready to use.
 type Query struct {
-	b      strings.Builder
-	params []any
+	Encryptor     *krypto.Encryptor
+	BlindIndexKey krypto.Key
+	b             strings.Builder
+	params        []any
+	err           error
 }
 
-// Query writes a non-parameterized part of a query.
-func (q *Query) Query(s string) {
+// Unsafe writes a non-parameterized part of a query.
+func (q *Query) Unsafe(s string) {
 	q.b.WriteString(s)
 }
 
@@ -21,6 +29,36 @@ func (q *Query) Query(s string) {
 func (q *Query) Param(v any) {
 	q.b.WriteString("?")
 	q.params = append(q.params, v)
+}
+
+// Param writes a parameterized part of a query and encrypts the value before adding it to the query.
+func (q *Query) ParamEncrypted(d []byte) {
+	if q.Encryptor == nil {
+		q.err = errors.New("no encryptor set")
+		return
+	}
+
+	enc, err := q.Encryptor.Encrypt(d)
+	if err != nil {
+		q.err = errors.Join(q.err, err)
+		return
+	}
+
+	q.Param(enc)
+}
+
+// ParamBlindIndex writes a parameterized part of a query and adds a blind index of the value to the query.
+// Important Note: The blind indexes will need to be rebuild if the key or argon2 parameters change.
+func (q *Query) ParamBlindIndex(d []byte) {
+	hash, err := krypto.HashArgon2WithKey(d, q.BlindIndexKey)
+	if err != nil {
+		q.err = errors.Join(q.err, err)
+		return
+	}
+
+	// overwrite the salt because we don't want to store it.
+	hash.Salt = nil
+	q.Param(hash.String())
 }
 
 // Params writes multiple parameterized parts of a query seperated by commas.
@@ -35,6 +73,34 @@ func (q *Query) Params(v ...any) {
 }
 
 // Get returns the constructed query and parameter values.
-func (q *Query) Get() (string, []any) {
-	return q.b.String(), q.params
+func (q *Query) Get() (string, []any, error) {
+	return q.b.String(), q.params, q.err
+}
+
+// DecryptionTarget returns a decryptable value that can be used to scan encrypted values.
+func (q *Query) DecryptionTarget() *Decryptable {
+	return &Decryptable{
+		encryptor: q.Encryptor,
+	}
+}
+
+type Decryptable struct {
+	encryptor *krypto.Encryptor
+	Data      []byte
+}
+
+func (d *Decryptable) Scan(src any) error {
+	b, ok := src.([]byte)
+	if !ok {
+		return errors.New("invalid type")
+	}
+
+	data, err := d.encryptor.Decrypt(b)
+	if err != nil {
+		return err
+	}
+
+	d.Data = data
+
+	return nil
 }

--- a/internal/krypto/argon2_hash.go
+++ b/internal/krypto/argon2_hash.go
@@ -40,14 +40,28 @@ type Argon2Hash struct {
 
 // HashArgon2 hashes a byte slice using the argon2id algorithm.
 func HashArgon2(b []byte) (Argon2Hash, error) {
-	if len(b) == 0 {
-		return Argon2Hash{}, fmt.Errorf("empty byte slice: %w", ErrInvalidInput)
-	}
-
 	// First we generate a salt.
 	salt, err := genRandomBytes(saltLen)
 	if err != nil {
 		return Argon2Hash{}, fmt.Errorf("failed to generate salt: %w", err)
+	}
+
+	return hashArgon2WithSalt(b, salt)
+}
+
+// HashArgon2WithKey hashes a byte slice using the argon2id algorithm and uses the provided key as a salt.
+func HashArgon2WithKey(b []byte, salt Key) (Argon2Hash, error) {
+	if len(salt.value) <= saltLen {
+		return Argon2Hash{}, fmt.Errorf("salt too short: %w", ErrInvalidInput)
+	}
+
+	return hashArgon2WithSalt(b, salt.value[:saltLen])
+}
+
+// hashArgon2WithSalt hashes a byte slice using the argon2id algorithm with the provided salt.
+func hashArgon2WithSalt(b []byte, salt []byte) (Argon2Hash, error) {
+	if len(b) == 0 {
+		return Argon2Hash{}, fmt.Errorf("empty byte slice: %w", ErrInvalidInput)
 	}
 
 	// Then we hash the bytes.

--- a/migrations/0001_users_and_email_tokens.sql
+++ b/migrations/0001_users_and_email_tokens.sql
@@ -1,19 +1,20 @@
 CREATE TABLE users(
-    id            INTEGER PRIMARY KEY,
-    email         TEXT NOT NULL UNIQUE,
-    password_hash TEXT NOT NULL,
-    is_active     INTEGER NOT NULL,
-    created_at    TIMESTAMP NOT NULL,
-    updated_at    TIMESTAMP NOT NULL
+    id                INTEGER PRIMARY KEY,
+    email_encrypted   TEXT NOT NULL,
+    email_blind_index TEXT NOT NULL UNIQUE,
+    password_hash     TEXT NOT NULL,
+    is_active         INTEGER NOT NULL,
+    created_at        TIMESTAMP NOT NULL,
+    updated_at        TIMESTAMP NOT NULL
 );
 
 CREATE TABLE email_tokens (
-    id          INTEGER PRIMARY KEY,
-    token_hash  TEXT NOT NULL,
-    user_id     INTEGER NOT NULL,
-    email       TEXT NOT NULL,
-    purpose     TEXT NOT NULL,
-    created_at  TIMESTAMP NOT NULL,
-    consumed_at TIMESTAMP,
+    id              INTEGER PRIMARY KEY,
+    token_hash      TEXT NOT NULL,
+    user_id         INTEGER NOT NULL,
+    email_encrypted TEXT NOT NULL,
+    purpose         TEXT NOT NULL,
+    created_at      TIMESTAMP NOT NULL,
+    consumed_at     TIMESTAMP,
     FOREIGN KEY(user_id) REFERENCES users(id)
 );

--- a/migrations/docs/schema.gen.sql
+++ b/migrations/docs/schema.gen.sql
@@ -5,20 +5,21 @@ CREATE TABLE migrations (
 	revision_timestamp TIMESTAMP NOT NULL
 );
 CREATE TABLE users(
-    id            INTEGER PRIMARY KEY,
-    email         TEXT NOT NULL UNIQUE,
-    password_hash TEXT NOT NULL,
-    is_active     INTEGER NOT NULL,
-    created_at    TIMESTAMP NOT NULL,
-    updated_at    TIMESTAMP NOT NULL
+    id                INTEGER PRIMARY KEY,
+    email_encrypted   TEXT NOT NULL,
+    email_blind_index TEXT NOT NULL UNIQUE,
+    password_hash     TEXT NOT NULL,
+    is_active         INTEGER NOT NULL,
+    created_at        TIMESTAMP NOT NULL,
+    updated_at        TIMESTAMP NOT NULL
 );
 CREATE TABLE email_tokens (
-    id          INTEGER PRIMARY KEY,
-    token_hash  TEXT NOT NULL,
-    user_id     INTEGER NOT NULL,
-    email       TEXT NOT NULL,
-    purpose     TEXT NOT NULL,
-    created_at  TIMESTAMP NOT NULL,
-    consumed_at TIMESTAMP,
+    id              INTEGER PRIMARY KEY,
+    token_hash      TEXT NOT NULL,
+    user_id         INTEGER NOT NULL,
+    email_encrypted TEXT NOT NULL,
+    purpose         TEXT NOT NULL,
+    created_at      TIMESTAMP NOT NULL,
+    consumed_at     TIMESTAMP,
     FOREIGN KEY(user_id) REFERENCES users(id)
 );


### PR DESCRIPTION
This PR ensures that any email addresses are encrypted before they are stored in the database.

One issues is that now emails can't be searched directly because they're encrypted. To still enable querying by email address, I also store a "blind index", a hashed value of the email address. This hash uses a salt that will be stored outside of the database.

## Why go through this effort?

In the future I want to backup my SQLite database to S3 or other external storage using [litestream](https://litestream.io/). Since I haven't done this before, my main purpose with these changes is to protect myself from my own mistakes.

If I end up inadvertently leaking my database, at least no plaintext credentials will get leaked.

In addition it provides a nice way to show a situation in which the format of the stored data is different from the data that is used in the application. The nice thing about these changes is that I did not have to touch anything in the `auth.Service`, all the work was more or less done in the `db` package.