### PR TITLE
4-authentication: authentication method

### DIFF
--- a/internal/auth/db/store.go
+++ b/internal/auth/db/store.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/willemschots/househunt/internal/auth"
+	"github.com/willemschots/househunt/internal/db"
 	"github.com/willemschots/househunt/internal/krypto"
 )
 
@@ -14,23 +15,32 @@ type NowFunc func() time.Time
 
 // Store is responsible for interacting with a database.
 type Store struct {
-	db            *sql.DB
+	writeDB       *sql.DB
+	readDB        *sql.DB
 	encryptor     *krypto.Encryptor
 	blindIndexKey krypto.Key
 }
 
 // New creates a new Store.
-func New(db *sql.DB, encryptor *krypto.Encryptor, blindIndexKey krypto.Key) *Store {
+func New(writeDB, readDB *sql.DB, encryptor *krypto.Encryptor, blindIndexKey krypto.Key) *Store {
 	return &Store{
-		db:            db,
+		writeDB:       writeDB,
+		readDB:        readDB,
 		encryptor:     encryptor,
 		blindIndexKey: blindIndexKey,
 	}
 }
 
+func (s *Store) newQuery() db.Query {
+	return db.Query{
+		Encryptor:     s.encryptor,
+		BlindIndexKey: s.blindIndexKey,
+	}
+}
+
 // BeginTx starts a new transaction.
 func (s *Store) BeginTx(ctx context.Context) (auth.Tx, error) {
-	tx, err := s.db.BeginTx(ctx, nil)
+	tx, err := s.writeDB.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -38,4 +48,10 @@ func (s *Store) BeginTx(ctx context.Context) (auth.Tx, error) {
 		tx:    tx,
 		store: s,
 	}, nil
+}
+
+func (s *Store) FindUsers(ctx context.Context, filter *auth.UserFilter) ([]auth.User, error) {
+	return selectUsers(s.newQuery(), func(query string, params ...any) (*sql.Rows, error) {
+		return s.readDB.QueryContext(ctx, query, params...)
+	}, filter)
 }

--- a/internal/auth/db/tx.go
+++ b/internal/auth/db/tx.go
@@ -4,19 +4,11 @@ import (
 	"database/sql"
 
 	"github.com/willemschots/househunt/internal/auth"
-	"github.com/willemschots/househunt/internal/db"
 )
 
 type Tx struct {
 	tx    *sql.Tx
 	store *Store
-}
-
-func (t *Tx) newQuery() db.Query {
-	return db.Query{
-		Encryptor:     t.store.encryptor,
-		BlindIndexKey: t.store.blindIndexKey,
-	}
 }
 
 func (t *Tx) Commit() error {
@@ -30,26 +22,26 @@ func (t *Tx) Rollback() error {
 // CreateUser creates a user in the database.
 // It updates the users ID, CreatedAt and UpdatedAt fields when successful.
 func (t *Tx) CreateUser(u *auth.User) error {
-	return insertUser(t.newQuery(), t.tx.Exec, u)
+	return insertUser(t.store.newQuery(), t.tx.Exec, u)
 }
 
 // UpdateUser updates a user in the database.
 // It updates the users UpdatedAt field when successful.
 // It returns errorz.ErrNotFound if no user is found.
 func (t *Tx) UpdateUser(u *auth.User) error {
-	return updateUser(t.newQuery(), t.tx.Exec, u)
+	return updateUser(t.store.newQuery(), t.tx.Exec, u)
 }
 
 // FindUsers queries for users based on the provided filter.
 // It returns an empty slice if no users are found.
 func (t *Tx) FindUsers(filter *auth.UserFilter) ([]auth.User, error) {
-	return selectUsers(t.newQuery(), t.tx.Query, filter)
+	return selectUsers(t.store.newQuery(), t.tx.Query, filter)
 }
 
 // CreateEmailToken creates an email token in the database.
 // It updates the token ID and CreatedAt when successful.
 func (t *Tx) CreateEmailToken(tok *auth.EmailToken) error {
-	return insertEmailToken(t.newQuery(), t.tx.Exec, tok)
+	return insertEmailToken(t.store.newQuery(), t.tx.Exec, tok)
 }
 
 // UpdateEmailToken updates an email token in the database.
@@ -57,10 +49,10 @@ func (t *Tx) CreateEmailToken(tok *auth.EmailToken) error {
 // It only allows updating the ConsumedAt field, attempting to
 // update any other field will return errorz.ErrConstraintViolated.
 func (t *Tx) UpdateEmailToken(tok *auth.EmailToken) error {
-	return updateEmailToken(t.newQuery(), t.tx.Exec, tok)
+	return updateEmailToken(t.store.newQuery(), t.tx.Exec, tok)
 }
 
 // FindEmailTokens queries for email tokens based on the provided filter.
 func (t *Tx) FindEmailTokens(filter *auth.EmailTokenFilter) ([]auth.EmailToken, error) {
-	return selectEmailTokens(t.newQuery(), t.tx.Query, filter)
+	return selectEmailTokens(t.store.newQuery(), t.tx.Query, filter)
 }

--- a/internal/auth/store.go
+++ b/internal/auth/store.go
@@ -28,6 +28,8 @@ type EmailTokenFilter struct {
 // Store provides access to the user store.
 type Store interface {
 	BeginTx(ctx context.Context) (Tx, error)
+
+	FindUsers(ctx context.Context, filter *UserFilter) ([]User, error)
 }
 
 // Tx is a transaction. If an error occurs on any of the Create/Update/Find methods,


### PR DESCRIPTION
In this PR the authentication method is added to the `auth.Service`.

An interesting detail is that we want both the failed/successful branches to take the same amount of time. Otherwise attackers could enumerate which accounts exist/don't exist by checking the amount of time a request takes.

A significant portion of time is spent hashing the input password, so I made sure this happens in both branches.

