### PR TITLE
4: Consistently use "user" over "account" and "user".

### DIFF
--- a/assets/emails/user-activation.tmpl
+++ b/assets/emails/user-activation.tmpl
@@ -4,6 +4,6 @@ Before we can activate your account and allow you to log in, we need to verify y
 
 Please click the following link to confirm your email address:
 
-https://examplego.com/account-activations?id={{.ID}}&token={{ .Token }}
+https://examplego.com/user-activations?id={{.ID}}&token={{ .Token }}
 
 {{ end }}

--- a/assets/templates/register-user.html
+++ b/assets/templates/register-user.html
@@ -3,7 +3,7 @@
 {{define "body"}}
 
 <h1>Register as an Agent</h1>
-<form action="/register" id="register-account">
+<form action="/register" id="register-user">
   <input type="email" name="email" placeholder="Email" required>
   <input type="password" name="password" placeholder="Password" required>
   <input type="submit" value="Register Account">

--- a/cmd/server/user_stories_test.go
+++ b/cmd/server/user_stories_test.go
@@ -15,14 +15,14 @@ func Test_UserStories(t *testing.T) {
 	t.Run("as an unauthenticated agent, I want to", func(t *testing.T) {
 		runAppForTest(t)
 
-		t.Run("view the account registration form", func(t *testing.T) {
+		t.Run("view the user registration form", func(t *testing.T) {
 			c := newClient(t)
 
 			body := c.MustGetBody("/register")
 
 			// Symbolic check for the form. I'm not checking the HTML too much,
 			// because I don't want every change to the front-end break these tests.
-			symbol := `id="register-account"`
+			symbol := `id="register-user"`
 			if !strings.Contains(body, symbol) {
 				t.Errorf("did not find\n%s\nin body\n%s", symbol, body)
 			}

--- a/internal/auth/email_token.go
+++ b/internal/auth/email_token.go
@@ -25,6 +25,6 @@ type EmailToken struct {
 type TokenPurpose string
 
 const (
-	// TokenPurposeActivate indicates a token should be used to activate an account.
+	// TokenPurposeActivate indicates a token should be used to activate an user.
 	TokenPurposeActivate TokenPurpose = "activate"
 )

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -79,7 +79,7 @@ func (s *Service) Wait() {
 }
 
 // RegisterAccount registers a new account for the provided credentials.
-// The main work of this method is done in a separate goroutine, the returned
+// The main work of this method is done in a separate goroutine. The returned
 // error does not indicate whether an account was created or not. This is by
 // design to prevent information leakage.
 func (s *Service) RegisterAccount(_ context.Context, c Credentials) error {
@@ -297,7 +297,8 @@ func (s *Service) Authenticate(ctx context.Context, c Credentials) (bool, error)
 	}
 
 	if len(users) != 1 {
-		// Still compare to a hash to prevent timing attacks.
+		// Even if no user is found we compare to a hash to prevent timing differences
+		// that could result in account enumeration attacks.
 		_ = c.Password.Match(s.comparisonHash)
 		return false, nil
 	}

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	ErrDuplicateAccount = errors.New("duplicate account")
+	ErrDuplicateUser = errors.New("duplicate user")
 )
 
 // Emailer is used to send templated emails.
@@ -78,11 +78,11 @@ func (s *Service) Wait() {
 	s.wg.Wait()
 }
 
-// RegisterAccount registers a new account for the provided credentials.
+// RegisterUser registers a new user with the provided credentials.
 // The main work of this method is done in a separate goroutine. The returned
-// error does not indicate whether an account was created or not. This is by
-// design to prevent information leakage.
-func (s *Service) RegisterAccount(_ context.Context, c Credentials) error {
+// error does not indicate whether a user was actually registered or not. This
+// is by design to prevent information leakage.
+func (s *Service) RegisterUser(_ context.Context, c Credentials) error {
 	// Hash the password.
 	pwdHash, err := c.Password.Hash()
 	if err != nil {
@@ -92,7 +92,7 @@ func (s *Service) RegisterAccount(_ context.Context, c Credentials) error {
 	// The actual work is done in a separate goroutine to prevent:
 	// - Waiting for the email to be send might slow down sending a response.
 	// - Information leakage. Timing difference between existing/non-existing
-	//   accounts could lead to account enumeration attacks.
+	//   user could lead to user enumeration attacks.
 	s.wg.Add(1)
 	go func() {
 		defer s.wg.Done()
@@ -106,17 +106,17 @@ func (s *Service) RegisterAccount(_ context.Context, c Credentials) error {
 		}
 	}()
 
-	// Note that we don't let the caller know if the account was created or not.
+	// Note that we don't let the caller know if the user was created or not.
 	// This is by design, again to prevent information leakage.
 	return nil
 }
 
-// startActivation begins the activation process of a new account:
-// - Create a new user if necessary.
+// startActivation begins the activation process for a new user:
+// - Create a new auth.User if necessary.
 // - Create a new email token.
-// - Send an email to address with an activation link.
+// - Send an email to the email address with an activation link.
 //
-// If an active user with the same email address exists, ErrDuplicateAccount is returned.
+// If an active user with the same email address exists, ErrDuplicateUser is returned.
 func (s *Service) startActivation(ctx context.Context, addr email.Address, pwdHash krypto.Argon2Hash) error {
 	now := s.NowFunc()
 
@@ -162,7 +162,7 @@ func (s *Service) startActivation(ctx context.Context, addr email.Address, pwdHa
 		// otherwise create a new user.
 		if len(users) > 0 {
 			if users[0].IsActive {
-				return ErrDuplicateAccount
+				return ErrDuplicateUser
 			}
 
 			emailToken.UserID = users[0].ID
@@ -193,7 +193,7 @@ func (s *Service) startActivation(ctx context.Context, addr email.Address, pwdHa
 	// risk for now. If the user has not received the email, they can always try to register again.
 	//
 	// If at some point this becomes unacceptable, we need to consider some kind of outbox pattern.
-	err = s.emailer.Send(ctx, "account-activation", user.Email, ActivationRequest{
+	err = s.emailer.Send(ctx, "user-activation", user.Email, ActivationRequest{
 		ID:    emailToken.ID,
 		Token: token,
 	})
@@ -204,14 +204,14 @@ func (s *Service) startActivation(ctx context.Context, addr email.Address, pwdHa
 	return nil
 }
 
-// ActivationRequest is a request to activate an account.
+// ActivationRequest is a request to activate an user.
 type ActivationRequest struct {
 	ID    int
 	Token krypto.Token
 }
 
-// ActivateAccount attempts to activate the requested account.
-func (s *Service) ActivateAccount(ctx context.Context, req ActivationRequest) error {
+// ActivateUser attempts to activate the user identified by the activation request.
+func (s *Service) ActivateUser(ctx context.Context, req ActivationRequest) error {
 	// finish the activation:
 	// - Find the token.
 	// - Check if the token is still valid.
@@ -244,7 +244,7 @@ func (s *Service) ActivateAccount(ctx context.Context, req ActivationRequest) er
 			return errorz.ErrNotFound
 		}
 
-		// Activate the corresponding user account.
+		// Activate the corresponding user.
 		users, err := tx.FindUsers(&UserFilter{
 			IDs:      []int{token.UserID},
 			IsActive: ptr(false),
@@ -298,7 +298,7 @@ func (s *Service) Authenticate(ctx context.Context, c Credentials) (bool, error)
 
 	if len(users) != 1 {
 		// Even if no user is found we compare to a hash to prevent timing differences
-		// that could result in account enumeration attacks.
+		// that could result in user enumeration attacks.
 		_ = c.Password.Match(s.comparisonHash)
 		return false, nil
 	}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -25,7 +25,7 @@ func NewServer(logger *slog.Logger, viewRenderer ViewRenderer) http.Handler {
 	mux.Handle("GET /register", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger.Info("register page requested")
 		w.WriteHeader(http.StatusOK)
-		err := viewRenderer.Render(w, "register-account", nil)
+		err := viewRenderer.Render(w, "register-user", nil)
 		if err != nil {
 			logger.Error("error rendering view", "error", err)
 		}


### PR DESCRIPTION
Starting the day with some small details: From the system perspective there is no difference between "an account" and a "user". This PR ensures we use consistent terminology in comments and code.

For emails and communication with the end-user we might still use "Your account" or similar.