### PR TITLE
4: Password reset methods

### DIFF
--- a/assets/emails/password-reset-request.tmpl
+++ b/assets/emails/password-reset-request.tmpl
@@ -1,0 +1,9 @@
+{{ block "subject" . }}Password reset requested{{ end }}
+{{ block "body" . }}
+A password reset has been requested for your account. If you did not request this, please ignore this email and contact us.
+
+To reset your password, please click the link below:
+
+https://examplego.com/password-resets?id={{.ID}}&token={{ .Token }}
+
+{{ end }}

--- a/assets/emails/password-reset-success.tmpl
+++ b/assets/emails/password-reset-success.tmpl
@@ -1,0 +1,5 @@
+{{ block "subject" . }}Your househunt password was reset{{ end }}
+{{ block "body" . }}
+Your househunt password was reset. If this wan't you, please contact us immediately.
+
+{{ end }}

--- a/internal/auth/email_token.go
+++ b/internal/auth/email_token.go
@@ -27,4 +27,6 @@ type TokenPurpose string
 const (
 	// TokenPurposeActivate indicates a token should be used to activate an user.
 	TokenPurposeActivate TokenPurpose = "activate"
+	// TokenPurposePasswordReset indicates a token should be used to reset a password.
+	TokenPurposePasswordReset TokenPurpose = "password_reset"
 )

--- a/internal/auth/email_token.go
+++ b/internal/auth/email_token.go
@@ -30,3 +30,9 @@ const (
 	// TokenPurposePasswordReset indicates a token should be used to reset a password.
 	TokenPurposePasswordReset TokenPurpose = "password_reset"
 )
+
+// EmailTokenRaw is the raw data that will be send to the user via email.
+type EmailTokenRaw struct {
+	ID    int
+	Token krypto.Token
+}

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -23,7 +23,9 @@ type Emailer interface {
 // ErrFunc is a function that handles errors.
 type ErrFunc func(error)
 
-// ServiceConfig is the configuration for the Service.
+// ServiceConfig is the configuration for the Service. Some methods run in seperate goroutines,
+// it is up to the caller to wait for these methods to finish. This can be done by calling the
+// Wait method.
 type ServiceConfig struct {
 	// WorkerTimeout is the max duration worker goroutines are allowed
 	// to take befor they are cancelled.
@@ -49,6 +51,7 @@ type Service struct {
 	NowFunc func() time.Time
 }
 
+// NewService creates a new Service.
 func NewService(s Store, emailer Emailer, errHandler ErrFunc, cfg ServiceConfig) (*Service, error) {
 	tok, err := krypto.GenerateToken()
 	if err != nil {

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -306,6 +306,18 @@ func (s *Service) Authenticate(ctx context.Context, c Credentials) (bool, error)
 	return c.Password.Match(users[0].PasswordHash), nil
 }
 
+// RequestPasswordReset requests a password reset for the user with the provided email address.
+// Similary to RegisterUser, the main work is done in a separate goroutine and no output is
+// returned to indicate if the request was successful.
+func (s *Service) RequestPasswordReset(ctx context.Context, addr email.Address) error {
+	// The actual work is done in a separate goroutine to prevent:
+	// - Waiting for the email to be send might slow down sending a response.
+	// - Information leakage. Timing difference between existing/non-existing
+	//   user could lead to user enumeration attacks.
+
+	return nil
+}
+
 func (s *Service) inTx(ctx context.Context, f func(tx Tx) error) error {
 	tx, err := s.store.BeginTx(ctx)
 	if err != nil {

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -18,298 +18,227 @@ import (
 
 func Test_Service_RegisterUser(t *testing.T) {
 	t.Run("ok, register user", func(t *testing.T) {
-		svc, deps := setupService(t)
+		st := newServiceTest(t)
 
 		credentials := auth.Credentials{
 			Email:    must(email.ParseAddress("info@example.com")),
 			Password: must(auth.ParsePassword("reallyStrongPassword1")),
 		}
 
-		err := svc.RegisterUser(context.Background(), credentials)
+		err := st.svc.RegisterUser(context.Background(), credentials)
 		if err != nil {
 			t.Fatalf("failed to register user: %v", err)
 		}
 
 		// Wait for service goroutine to finish registering.
-		svc.Wait()
+		st.svc.Wait()
 
 		// Verify no errors were reported to the error handler.
-		deps.errList.assertNoError(t)
+		st.errList.assertNoError(t)
 
 		// Assert that an email was send to the email address.
-		if len(deps.emailer.emails) != 1 || deps.emailer.emails[0].recipient != credentials.Email {
-			t.Fatalf("expected 1 email to %s, got %d", credentials.Email, len(deps.emailer.emails))
+		if len(st.emailer.emails) != 1 || st.emailer.emails[0].recipient != credentials.Email {
+			t.Fatalf("expected 1 email to %s, got %d", credentials.Email, len(st.emailer.emails))
 		}
 	})
 
 	t.Run("ok, re-register non-activated user", func(t *testing.T) {
-		svc, deps := setupService(t)
+		st := newServiceTest(t)
 
-		credentials := auth.Credentials{
-			Email:    must(email.ParseAddress("info@example.com")),
-			Password: must(auth.ParsePassword("reallyStrongPassword1")),
-		}
-
-		// Register once.
-		err := svc.RegisterUser(context.Background(), credentials)
-		if err != nil {
-			t.Fatalf("failed to register user: %v", err)
-		}
-
-		// Wait for service goroutine to finish.
-		svc.Wait()
+		// Register an initial user, but don't activate it.
+		credentials, _ := st.registerUser()
 
 		// Register again.
-		err = svc.RegisterUser(context.Background(), credentials)
+		err := st.svc.RegisterUser(context.Background(), credentials)
 		if err != nil {
 			t.Fatalf("failed to register user: %v", err)
 		}
 
 		// Wait for service goroutine to finish registering.
-		svc.Wait()
+		st.svc.Wait()
 
 		// Verify no errors were reported to the error handler.
-		deps.errList.assertNoError(t)
+		st.errList.assertNoError(t)
 
-		// Assert two single email were send.
-		if len(deps.emailer.emails) != 2 {
-			t.Fatalf("expected 2 emails, got %d", len(deps.emailer.emails))
+		// Assert two emails were send.
+		if len(st.emailer.emails) != 2 {
+			t.Fatalf("expected 2 emails, got %d", len(st.emailer.emails))
 		}
 	})
 
 	t.Run("fail async, re-register active user", func(t *testing.T) {
-		svc, deps := setupService(t)
+		st := newServiceTest(t)
 
-		credentials := auth.Credentials{
-			Email:    must(email.ParseAddress("info@example.com")),
-			Password: must(auth.ParsePassword("reallyStrongPassword1")),
-		}
-
-		// Register once.
-		err := svc.RegisterUser(context.Background(), credentials)
-		if err != nil {
-			t.Fatalf("failed to register user: %v", err)
-		}
-
-		// Wait for service goroutine to finish registering.
-		svc.Wait()
-
-		// Activate the user.
-		if len(deps.emailer.emails) != 1 {
-			t.Fatalf("expected 1 email, got %d", len(deps.emailer.emails))
-		}
-
-		request, ok := deps.emailer.emails[0].data.(auth.ActivationRequest)
-		if !ok {
-			t.Fatalf("unexpected data type: %T", deps.emailer.emails[0].data)
-		}
-
-		err = svc.ActivateUser(context.Background(), request)
-		if err != nil {
-			t.Fatalf("failed to activate user: %v", err)
-		}
-
-		// Wait for service goroutine to finish activating.
-		svc.Wait()
+		// Register an initial user and activate it.
+		credentials, request := st.registerUser()
+		st.activateUser(request)
 
 		// Register again.
-		err = svc.RegisterUser(context.Background(), credentials)
+		err := st.svc.RegisterUser(context.Background(), credentials)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		svc.Wait()
+		st.svc.Wait()
 
 		// Now we should have an error.
-		deps.errList.assertErrorIs(t, auth.ErrDuplicateUser)
+		st.errList.assertErrorIs(t, auth.ErrDuplicateUser)
 	})
 
 	// TODO: add case "fail async, too many registration requests"
 
 	for _, tracker := range testerr.NewFailingDeps(testerr.Err, 5) {
 		t.Run("fail async, store fails", func(t *testing.T) {
-			svc, deps := setupService(t)
-			deps.store.tracker = &tracker
+			st := newServiceTest(t)
+			st.store.tracker = &tracker
 
 			credentials := auth.Credentials{
 				Email:    must(email.ParseAddress("info@example.com")),
 				Password: must(auth.ParsePassword("reallyStrongPassword1")),
 			}
 
-			err := svc.RegisterUser(context.Background(), credentials)
+			err := st.svc.RegisterUser(context.Background(), credentials)
 			if err != nil {
 				t.Fatalf("failed to register user: %v", err)
 			}
 
 			// Wait for service goroutine to finish registering.
-			svc.Wait()
+			st.svc.Wait()
 
-			deps.errList.assertErrorIs(t, testerr.Err)
+			st.errList.assertErrorIs(t, testerr.Err)
 
 			// Assert no email was send.
-			if len(deps.emailer.emails) != 0 {
-				t.Fatalf("expected 0 emails, got %d", len(deps.emailer.emails))
+			if len(st.emailer.emails) != 0 {
+				t.Fatalf("expected 0 emails, got %d", len(st.emailer.emails))
 			}
 		})
 	}
 
 	t.Run("fail sync, emailer fails", func(t *testing.T) {
-		svc, deps := setupService(t)
-		deps.emailer.testErr = testerr.Err
+		st := newServiceTest(t)
+		st.emailer.testErr = testerr.Err
 
 		credentials := auth.Credentials{
 			Email:    must(email.ParseAddress("info@example.com")),
 			Password: must(auth.ParsePassword("reallyStrongPassword1")),
 		}
 
-		err := svc.RegisterUser(context.Background(), credentials)
+		err := st.svc.RegisterUser(context.Background(), credentials)
 		if err != nil {
 			t.Fatalf("failed to register user: %v", err)
 		}
 
 		// Wait for service goroutine to finish registering.
-		svc.Wait()
+		st.svc.Wait()
 
-		deps.errList.assertErrorIs(t, testerr.Err)
+		st.errList.assertErrorIs(t, testerr.Err)
 	})
 }
 
 func Test_Service_ActivateUser(t *testing.T) {
-	registerAndGetRequest := func(t *testing.T, svc *auth.Service, deps *svcDeps) auth.ActivationRequest {
-		err := svc.RegisterUser(context.Background(), auth.Credentials{
-			Email:    must(email.ParseAddress("info@example.com")),
-			Password: must(auth.ParsePassword("reallyStrongPassword1")),
-		})
-		if err != nil {
-			t.Fatalf("failed to register user: %v", err)
-		}
-
-		// wait for the service goroutine to finish registering.
-		svc.Wait()
-
-		// Get the last email
-		index := len(deps.emailer.emails) - 1
-		request, ok := deps.emailer.emails[index].data.(auth.ActivationRequest)
-		if !ok {
-			t.Fatalf("unexpected data type: %T", deps.emailer.emails[index].data)
-		}
-
-		return request
-	}
-
-	// setup the test by registering an user and getting the activation request.
-	setup := func(t *testing.T) (*auth.Service, *svcDeps, auth.ActivationRequest) {
-		svc, deps := setupService(t)
-
-		request := registerAndGetRequest(t, svc, deps)
-
-		return svc, deps, request
-	}
-
 	t.Run("ok, activate non-activated user", func(t *testing.T) {
-		svc, deps, req := setup(t)
+		st := newServiceTest(t)
+		_, req := st.registerUser()
 
-		err := svc.ActivateUser(context.Background(), req)
+		err := st.svc.ActivateUser(context.Background(), req)
 		if err != nil {
 			t.Fatalf("failed to activate user: %v", err)
 		}
 
 		// assert no async errors were reported.
-		svc.Wait()
-		deps.errList.assertNoError(t)
+		st.svc.Wait()
+		st.errList.assertNoError(t)
 	})
 
 	t.Run("fail, non-matching token", func(t *testing.T) {
-		svc, deps, req := setup(t)
+		st := newServiceTest(t)
+		_, req := st.registerUser()
 
 		req.Token = must(krypto.ParseToken("0102030405060708091011121314151617181920212223242526272829303132"))
 
-		err := svc.ActivateUser(context.Background(), req)
+		err := st.svc.ActivateUser(context.Background(), req)
 		if !errors.Is(err, errorz.ErrNotFound) {
 			t.Fatalf("expected error %v, got %v", errorz.ErrNotFound, err)
 		}
 
 		// assert no async errors were reported.
-		svc.Wait()
-		deps.errList.assertNoError(t)
+		st.svc.Wait()
+		st.errList.assertNoError(t)
 	})
 
 	t.Run("fail, non-existant token", func(t *testing.T) {
-		svc, deps, req := setup(t)
+		st := newServiceTest(t)
+		_, req := st.registerUser()
 
 		req.ID = 2
 
-		err := svc.ActivateUser(context.Background(), req)
+		err := st.svc.ActivateUser(context.Background(), req)
 		if !errors.Is(err, errorz.ErrNotFound) {
 			t.Fatalf("expected error %v, got %v", errorz.ErrNotFound, err)
 		}
 
 		// assert no async errors were reported.
-		svc.Wait()
-		deps.errList.assertNoError(t)
+		st.svc.Wait()
+		st.errList.assertNoError(t)
 	})
 
 	t.Run("fail, token already consumed", func(t *testing.T) {
-		svc, deps, req := setup(t)
+		st := newServiceTest(t)
+		_, req := st.registerUser()
 
-		err := svc.ActivateUser(context.Background(), req)
-		if err != nil {
-			t.Fatalf("failed to activate user: %v", err)
-		}
-		// wait for the service goroutine to finish activating.
-		svc.Wait()
+		// Consume token once.
+		st.activateUser(req)
 
-		err = svc.ActivateUser(context.Background(), req)
+		// Consume token again.
+		err := st.svc.ActivateUser(context.Background(), req)
 		if !errors.Is(err, errorz.ErrNotFound) {
 			t.Fatalf("expected error %v, got %v", errorz.ErrNotFound, err)
 		}
 
 		// assert no async errors were reported.
-		svc.Wait()
-		deps.errList.assertNoError(t)
+		st.svc.Wait()
+		st.errList.assertNoError(t)
 	})
 
 	t.Run("fail, other token used to activate user", func(t *testing.T) {
-		svc, deps, req1 := setup(t)
+		st := newServiceTest(t)
 
-		req2 := registerAndGetRequest(t, svc, deps)
+		// register same user twice.
+		_, req1 := st.registerUser()
+		_, req2 := st.registerUser()
 
-		err := svc.ActivateUser(context.Background(), req2)
-		if err != nil {
-			t.Fatalf("failed to activate user: %v", err)
-		}
-
-		// wait for the service goroutine to finish activating.
-		svc.Wait()
+		// activate user with the second token.
+		st.activateUser(req2)
 
 		// now try with the first token.
-		err = svc.ActivateUser(context.Background(), req1)
+		err := st.svc.ActivateUser(context.Background(), req1)
 		if !errors.Is(err, errorz.ErrNotFound) {
 			t.Fatalf("expected error %v, got %v", errorz.ErrNotFound, err)
 		}
 
 		// assert no async errors were reported.
-		svc.Wait()
-		deps.errList.assertNoError(t)
+		st.svc.Wait()
+		st.errList.assertNoError(t)
 	})
 
 	t.Run("fail, expired token", func(t *testing.T) {
-		svc, deps, req := setup(t)
+		st := newServiceTest(t)
+		_, req := st.registerUser()
 
 		// TokenExpiry is set to 1 hour.
 		// Simulate the current time being an hour ahead.
-		svc.NowFunc = func() time.Time {
+		st.svc.NowFunc = func() time.Time {
 			return time.Now().Add(time.Hour + time.Second)
 		}
 
-		err := svc.ActivateUser(context.Background(), req)
+		err := st.svc.ActivateUser(context.Background(), req)
 		if !errors.Is(err, errorz.ErrNotFound) {
 			t.Fatalf("expected error %v, got %v", errorz.ErrNotFound, err)
 		}
 
 		// assert no async errors were reported.
-		svc.Wait()
-		deps.errList.assertNoError(t)
+		st.svc.Wait()
+		st.errList.assertNoError(t)
 	})
 
 	//t.Run("fail, token for different purpose", func(t *testing.T) {
@@ -318,58 +247,29 @@ func Test_Service_ActivateUser(t *testing.T) {
 
 	for _, tracker := range testerr.NewFailingDeps(testerr.Err, 6) {
 		t.Run("fail, store fails", func(t *testing.T) {
-			svc, deps, req := setup(t)
-			deps.store.tracker = &tracker
+			st := newServiceTest(t)
+			_, req := st.registerUser()
+			st.store.tracker = &tracker
 
-			err := svc.ActivateUser(context.Background(), req)
+			err := st.svc.ActivateUser(context.Background(), req)
 			if !errors.Is(err, testerr.Err) {
 				t.Fatalf("expected error %v, got %v (via errors.Is)", testerr.Err, err)
 			}
 
 			// assert no async errors were reported.
-			svc.Wait()
-			deps.errList.assertNoError(t)
+			st.svc.Wait()
+			st.errList.assertNoError(t)
 		})
 	}
 }
 
 func Test_Service_Authenticate(t *testing.T) {
-	setup := func(t *testing.T, activate bool) (*auth.Service, *svcDeps, auth.Credentials) {
-		svc, deps := setupService(t)
-
-		credentials := auth.Credentials{
-			Email:    must(email.ParseAddress("info@example.com")),
-			Password: must(auth.ParsePassword("reallyStrongPassword1")),
-		}
-
-		err := svc.RegisterUser(context.Background(), credentials)
-		if err != nil {
-			t.Fatalf("failed to register user: %v", err)
-		}
-
-		svc.Wait()
-
-		if activate {
-			// Get the last email that was sent to retrieve the activation request.
-			index := len(deps.emailer.emails) - 1
-			request, ok := deps.emailer.emails[index].data.(auth.ActivationRequest)
-			if !ok {
-				t.Fatalf("unexpected data type: %T", deps.emailer.emails[index].data)
-			}
-
-			err = svc.ActivateUser(context.Background(), request)
-			if err != nil {
-				t.Fatalf("failed to activate user: %v", err)
-			}
-		}
-
-		return svc, deps, credentials
-	}
-
 	t.Run("ok, right credentials", func(t *testing.T) {
-		svc, deps, credentials := setup(t, true)
+		st := newServiceTest(t)
+		credentials, req := st.registerUser()
+		st.activateUser(req)
 
-		authenticated, err := svc.Authenticate(context.Background(), credentials)
+		authenticated, err := st.svc.Authenticate(context.Background(), credentials)
 		if err != nil {
 			t.Fatalf("failed to authenticate: %v", err)
 		}
@@ -379,16 +279,18 @@ func Test_Service_Authenticate(t *testing.T) {
 		}
 
 		// assert no async errors were reported.
-		svc.Wait()
-		deps.errList.assertNoError(t)
+		st.svc.Wait()
+		st.errList.assertNoError(t)
 	})
 
 	t.Run("ok, failed to authenticate, wrong password", func(t *testing.T) {
-		svc, deps, credentials := setup(t, true)
+		st := newServiceTest(t)
+		credentials, req := st.registerUser()
+		st.activateUser(req)
 
 		credentials.Password = must(auth.ParsePassword("wrongPassword"))
 
-		authenticated, err := svc.Authenticate(context.Background(), credentials)
+		authenticated, err := st.svc.Authenticate(context.Background(), credentials)
 		if err != nil {
 			t.Fatalf("failed to authenticate: %v", err)
 		}
@@ -398,16 +300,18 @@ func Test_Service_Authenticate(t *testing.T) {
 		}
 
 		// assert no async errors were reported.
-		svc.Wait()
-		deps.errList.assertNoError(t)
+		st.svc.Wait()
+		st.errList.assertNoError(t)
 	})
 
 	t.Run("ok, failed to authenticate, non-existant user", func(t *testing.T) {
-		svc, deps, credentials := setup(t, true)
+		st := newServiceTest(t)
+		credentials, req := st.registerUser()
+		st.activateUser(req)
 
 		credentials.Email = must(email.ParseAddress("jacob@example.com"))
 
-		authenticated, err := svc.Authenticate(context.Background(), credentials)
+		authenticated, err := st.svc.Authenticate(context.Background(), credentials)
 		if err != nil {
 			t.Fatalf("failed to authenticate: %v", err)
 		}
@@ -417,14 +321,15 @@ func Test_Service_Authenticate(t *testing.T) {
 		}
 
 		// assert no async errors were reported.
-		svc.Wait()
-		deps.errList.assertNoError(t)
+		st.svc.Wait()
+		st.errList.assertNoError(t)
 	})
 
 	t.Run("ok, failed to authenticate, inactive user", func(t *testing.T) {
-		svc, deps, credentials := setup(t, false)
+		st := newServiceTest(t)
+		credentials, _ := st.registerUser()
 
-		authenticated, err := svc.Authenticate(context.Background(), credentials)
+		authenticated, err := st.svc.Authenticate(context.Background(), credentials)
 		if err != nil {
 			t.Fatalf("failed to authenticate: %v", err)
 		}
@@ -434,24 +339,110 @@ func Test_Service_Authenticate(t *testing.T) {
 		}
 
 		// assert no async errors were reported.
-		svc.Wait()
-		deps.errList.assertNoError(t)
+		st.svc.Wait()
+		st.errList.assertNoError(t)
 	})
 
 	t.Run("fail, store fails", func(t *testing.T) {
-		svc, deps, credentials := setup(t, true)
-		failingDeps := testerr.NewFailingDeps(testerr.Err, 1)
-		deps.store.tracker = &failingDeps[0]
+		st := newServiceTest(t)
+		credentials, req := st.registerUser()
+		st.activateUser(req)
 
-		_, err := svc.Authenticate(context.Background(), credentials)
+		failingDeps := testerr.NewFailingDeps(testerr.Err, 1)
+		st.store.tracker = &failingDeps[0]
+
+		_, err := st.svc.Authenticate(context.Background(), credentials)
 		if !errors.Is(err, testerr.Err) {
 			t.Fatalf("expected error %v, got %v (via errors.Is)", testerr.Err, err)
 		}
 
 		// assert no async errors were reported.
-		svc.Wait()
-		deps.errList.assertNoError(t)
+		st.svc.Wait()
+		st.errList.assertNoError(t)
 	})
+}
+
+type svcTest struct {
+	t       *testing.T
+	svc     *auth.Service
+	store   *testStore
+	emailer *testEmailer
+	errList *errList
+	nowFunc func() time.Time
+}
+
+func newServiceTest(t *testing.T) *svcTest {
+	encryptor := must(krypto.NewEncryptor([]krypto.Key{
+		must(krypto.ParseKey("2b671594b775f371eab4050b4d58326682df6b1a6cc2e886717b1a26b4d6c45d")),
+	}))
+
+	indexKey := must(krypto.ParseKey("90303dfed7994260ea4817a5ca8a392915cd401115b2f97495dadfcbcd14adbf"))
+
+	testDB := testdb.RunWhile(t, true)
+	test := &svcTest{
+		t: t,
+		store: &testStore{
+			store:   db.New(testDB, testDB, encryptor, indexKey),
+			tracker: &testerr.Calltracker{}, // empty call trackers never fail.
+		},
+		errList: &errList{
+			mutex: &sync.Mutex{},
+			errs:  make([]error, 0),
+		},
+		emailer: &testEmailer{},
+		nowFunc: func() time.Time {
+			return time.Now().Round(0)
+		},
+	}
+
+	cfg := auth.ServiceConfig{
+		WorkerTimeout: time.Second,
+		TokenExpiry:   time.Hour,
+	}
+
+	svc, err := auth.NewService(test.store, test.emailer, test.errList.AppendErr, cfg)
+	if err != nil {
+		t.Fatalf("failed to create service: %v", err)
+	}
+
+	test.svc = svc
+
+	return test
+}
+
+func (st *svcTest) registerUser() (auth.Credentials, auth.ActivationRequest) {
+	credentials := auth.Credentials{
+		Email:    must(email.ParseAddress("info@example.com")),
+		Password: must(auth.ParsePassword("reallyStrongPassword1")),
+	}
+	err := st.svc.RegisterUser(context.Background(), credentials)
+	if err != nil {
+		st.t.Fatalf("failed to register user: %v", err)
+	}
+
+	// wait for the service goroutine to finish registering.
+	st.svc.Wait()
+	st.errList.assertNoError(st.t)
+
+	// Get the last email
+	index := len(st.emailer.emails) - 1
+	request, ok := st.emailer.emails[index].data.(auth.ActivationRequest)
+	if !ok {
+		st.t.Fatalf("unexpected data type: %T", st.emailer.emails[index].data)
+	}
+
+	return credentials, request
+}
+
+func (st *svcTest) activateUser(req auth.ActivationRequest) {
+	err := st.svc.ActivateUser(context.Background(), req)
+	if err != nil {
+		st.t.Fatalf("failed to activate user: %v", err)
+	}
+
+	// wait for the service goroutine to finish activating.
+	st.svc.Wait()
+	st.errList.assertNoError(st.t)
 }
 
 type errList struct {
@@ -489,49 +480,6 @@ func (e *errList) assertErrorIs(t *testing.T, err error) {
 	if len(e.errs) != 1 || !errors.Is(e.errs[0], err) {
 		t.Fatalf("expected error %v, got %v via errors.Is()", err, e.errs)
 	}
-}
-
-type svcDeps struct {
-	store   *testStore
-	emailer *testEmailer
-	errList *errList
-	nowFunc func() time.Time
-}
-
-func setupService(t *testing.T) (*auth.Service, *svcDeps) {
-	encryptor := must(krypto.NewEncryptor([]krypto.Key{
-		must(krypto.ParseKey("2b671594b775f371eab4050b4d58326682df6b1a6cc2e886717b1a26b4d6c45d")),
-	}))
-
-	indexKey := must(krypto.ParseKey("90303dfed7994260ea4817a5ca8a392915cd401115b2f97495dadfcbcd14adbf"))
-
-	testDB := testdb.RunWhile(t, true)
-	deps := &svcDeps{
-		store: &testStore{
-			store:   db.New(testDB, testDB, encryptor, indexKey),
-			tracker: &testerr.Calltracker{}, // empty call trackers never fail.
-		},
-		errList: &errList{
-			mutex: &sync.Mutex{},
-			errs:  make([]error, 0),
-		},
-		emailer: &testEmailer{},
-		nowFunc: func() time.Time {
-			return time.Now().Round(0)
-		},
-	}
-
-	cfg := auth.ServiceConfig{
-		WorkerTimeout: time.Second,
-		TokenExpiry:   time.Hour,
-	}
-
-	svc, err := auth.NewService(deps.store, deps.emailer, deps.errList.AppendErr, cfg)
-	if err != nil {
-		t.Fatalf("failed to create service: %v", err)
-	}
-
-	return svc, deps
 }
 
 // testStore wraps a real store but uses a testerr.Calltracker to


### PR DESCRIPTION
This PR (finally!) adds the password reset methods:
- `RequestPasswordReset` Requests a new password, it sends a link to the user's email address via which they can configure a new password. The link will contain a token, just like with the account activation mechanism.
- `ResetPassword` consumes the token and will reset the password.

When adding this to the handlers, we need to be careful to log out the users if a password has been reset.