### PR TITLE
4-uuid: use uuid's instead of numeric ids

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,7 @@ require (
 	golang.org/x/sync v0.6.0
 )
 
-require golang.org/x/sys v0.18.0 // indirect
+require (
+	github.com/google/uuid v1.6.0 // indirect
+	golang.org/x/sys v0.18.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/mattn/go-sqlite3 v1.14.22 h1:2gZY6PC6kBnID23Tichd1K+Z0oS6nE/XwU+Vz/5o4kU=
 github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
 golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=

--- a/internal/auth/db/store.go
+++ b/internal/auth/db/store.go
@@ -50,7 +50,7 @@ func (s *Store) BeginTx(ctx context.Context) (auth.Tx, error) {
 	}, nil
 }
 
-func (s *Store) FindUsers(ctx context.Context, filter *auth.UserFilter) ([]auth.User, error) {
+func (s *Store) FindUsers(ctx context.Context, filter auth.UserFilter) ([]auth.User, error) {
 	return selectUsers(s.newQuery(), func(query string, params ...any) (*sql.Rows, error) {
 		return s.readDB.QueryContext(ctx, query, params...)
 	}, filter)

--- a/internal/auth/db/tx.go
+++ b/internal/auth/db/tx.go
@@ -21,26 +21,26 @@ func (t *Tx) Rollback() error {
 
 // CreateUser creates a user in the database.
 // It updates the users ID, CreatedAt and UpdatedAt fields when successful.
-func (t *Tx) CreateUser(u *auth.User) error {
+func (t *Tx) CreateUser(u auth.User) error {
 	return insertUser(t.store.newQuery(), t.tx.Exec, u)
 }
 
 // UpdateUser updates a user in the database.
 // It updates the users UpdatedAt field when successful.
 // It returns errorz.ErrNotFound if no user is found.
-func (t *Tx) UpdateUser(u *auth.User) error {
+func (t *Tx) UpdateUser(u auth.User) error {
 	return updateUser(t.store.newQuery(), t.tx.Exec, u)
 }
 
 // FindUsers queries for users based on the provided filter.
 // It returns an empty slice if no users are found.
-func (t *Tx) FindUsers(filter *auth.UserFilter) ([]auth.User, error) {
+func (t *Tx) FindUsers(filter auth.UserFilter) ([]auth.User, error) {
 	return selectUsers(t.store.newQuery(), t.tx.Query, filter)
 }
 
 // CreateEmailToken creates an email token in the database.
 // It updates the token ID and CreatedAt when successful.
-func (t *Tx) CreateEmailToken(tok *auth.EmailToken) error {
+func (t *Tx) CreateEmailToken(tok auth.EmailToken) error {
 	return insertEmailToken(t.store.newQuery(), t.tx.Exec, tok)
 }
 
@@ -48,11 +48,11 @@ func (t *Tx) CreateEmailToken(tok *auth.EmailToken) error {
 // It returns errorz.ErrNotFound if no email token is found.
 // It only allows updating the ConsumedAt field, attempting to
 // update any other field will return errorz.ErrConstraintViolated.
-func (t *Tx) UpdateEmailToken(tok *auth.EmailToken) error {
+func (t *Tx) UpdateEmailToken(tok auth.EmailToken) error {
 	return updateEmailToken(t.store.newQuery(), t.tx.Exec, tok)
 }
 
 // FindEmailTokens queries for email tokens based on the provided filter.
-func (t *Tx) FindEmailTokens(filter *auth.EmailTokenFilter) ([]auth.EmailToken, error) {
+func (t *Tx) FindEmailTokens(filter auth.EmailTokenFilter) ([]auth.EmailToken, error) {
 	return selectEmailTokens(t.store.newQuery(), t.tx.Query, filter)
 }

--- a/internal/auth/email_token.go
+++ b/internal/auth/email_token.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/willemschots/househunt/internal/email"
 	"github.com/willemschots/househunt/internal/krypto"
 )
@@ -10,11 +11,11 @@ import (
 // EmailToken contains the state of a token that was sent via email.
 // Such tokens should be only used once and have a limited lifetime.
 type EmailToken struct {
-	ID int
+	ID uuid.UUID
 	// TokenHash is the hash of the token. We hash the token to prevent someone with
 	// access to the database from mis-using the tokens.
 	TokenHash  krypto.Argon2Hash
-	UserID     int
+	UserID     uuid.UUID
 	Email      email.Address
 	Purpose    TokenPurpose
 	CreatedAt  time.Time
@@ -33,6 +34,6 @@ const (
 
 // EmailTokenRaw is the raw data that will be send to the user via email.
 type EmailTokenRaw struct {
-	ID    int
+	ID    uuid.UUID
 	Token krypto.Token
 }

--- a/internal/auth/service_test.go
+++ b/internal/auth/service_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/willemschots/househunt/internal/auth"
 	"github.com/willemschots/househunt/internal/auth/db"
 	"github.com/willemschots/househunt/internal/db/testdb"
@@ -42,7 +43,7 @@ func Test_Service_RegisterUser(t *testing.T) {
 			if !ok {
 				t.Fatalf("unexpected data type: %T", data)
 			}
-			if req.ID == 0 {
+			if req.ID == uuid.Nil {
 				t.Fatalf("expected ID to be set")
 			}
 			if len(req.Token) == 0 {
@@ -74,7 +75,7 @@ func Test_Service_RegisterUser(t *testing.T) {
 			if !ok {
 				t.Fatalf("unexpected data type: %T", data)
 			}
-			if req.ID == 0 {
+			if req.ID == uuid.Nil {
 				t.Fatalf("expected ID to be set")
 			}
 			if len(req.Token) == 0 {
@@ -181,7 +182,7 @@ func Test_Service_ActivateUser(t *testing.T) {
 		st := newServiceTest(t)
 		_, tok := st.registerUser()
 
-		tok.ID = 2
+		tok.ID = uuid.New()
 
 		err := st.svc.ActivateUser(context.Background(), tok)
 		if !errors.Is(err, errorz.ErrNotFound) {
@@ -407,7 +408,7 @@ func Test_Service_RequestPasswordReset(t *testing.T) {
 			if !ok {
 				t.Fatalf("unexpected data type: %T", data)
 			}
-			if resetTok.ID == 0 {
+			if resetTok.ID == uuid.Nil {
 				t.Fatalf("expected ID to be set")
 			}
 			if len(resetTok.Token) == 0 {
@@ -556,7 +557,7 @@ func Test_Service_ResetPassword(t *testing.T) {
 			RawToken: resetTok,
 		}
 
-		newPass.RawToken.ID = 3
+		newPass.RawToken.ID = uuid.New()
 
 		err := st.svc.ResetPassword(context.Background(), newPass)
 		if !errors.Is(err, errorz.ErrNotFound) {
@@ -906,7 +907,7 @@ func (f *testStore) BeginTx(ctx context.Context) (auth.Tx, error) {
 	})
 }
 
-func (f *testStore) FindUsers(ctx context.Context, filter *auth.UserFilter) ([]auth.User, error) {
+func (f *testStore) FindUsers(ctx context.Context, filter auth.UserFilter) ([]auth.User, error) {
 	return testerr.MaybeFail(f.tracker, func() ([]auth.User, error) {
 		return f.store.FindUsers(ctx, filter)
 	})
@@ -929,37 +930,37 @@ func (tx *testTx) Rollback() error {
 	})
 }
 
-func (tx *testTx) CreateUser(u *auth.User) error {
+func (tx *testTx) CreateUser(u auth.User) error {
 	return testerr.MaybeFailErrFunc(tx.store.tracker, func() error {
 		return tx.tx.CreateUser(u)
 	})
 }
 
-func (tx *testTx) UpdateUser(u *auth.User) error {
+func (tx *testTx) UpdateUser(u auth.User) error {
 	return testerr.MaybeFailErrFunc(tx.store.tracker, func() error {
 		return tx.tx.UpdateUser(u)
 	})
 }
 
-func (tx *testTx) FindUsers(filter *auth.UserFilter) ([]auth.User, error) {
+func (tx *testTx) FindUsers(filter auth.UserFilter) ([]auth.User, error) {
 	return testerr.MaybeFail(tx.store.tracker, func() ([]auth.User, error) {
 		return tx.tx.FindUsers(filter)
 	})
 }
 
-func (tx *testTx) CreateEmailToken(t *auth.EmailToken) error {
+func (tx *testTx) CreateEmailToken(t auth.EmailToken) error {
 	return testerr.MaybeFailErrFunc(tx.store.tracker, func() error {
 		return tx.tx.CreateEmailToken(t)
 	})
 }
 
-func (tx *testTx) UpdateEmailToken(t *auth.EmailToken) error {
+func (tx *testTx) UpdateEmailToken(t auth.EmailToken) error {
 	return testerr.MaybeFailErrFunc(tx.store.tracker, func() error {
 		return tx.tx.UpdateEmailToken(t)
 	})
 }
 
-func (tx *testTx) FindEmailTokens(filter *auth.EmailTokenFilter) ([]auth.EmailToken, error) {
+func (tx *testTx) FindEmailTokens(filter auth.EmailTokenFilter) ([]auth.EmailToken, error) {
 	return testerr.MaybeFail(tx.store.tracker, func() ([]auth.EmailToken, error) {
 		return tx.tx.FindEmailTokens(filter)
 	})

--- a/internal/auth/store.go
+++ b/internal/auth/store.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 
+	"github.com/google/uuid"
 	"github.com/willemschots/househunt/internal/email"
 )
 
@@ -10,7 +11,7 @@ import (
 // Returned users must match all the provided fields.
 // If a field is empty or nil, it's ignored.
 type UserFilter struct {
-	IDs      []int
+	IDs      []uuid.UUID
 	Emails   []email.Address
 	IsActive *bool
 }
@@ -19,8 +20,8 @@ type UserFilter struct {
 // Returned tokens must match all the provided fields.
 // If a field is empty or nil, it's ignored.
 type EmailTokenFilter struct {
-	IDs        []int
-	UserIDs    []int
+	IDs        []uuid.UUID
+	UserIDs    []uuid.UUID
 	Purposes   []TokenPurpose
 	IsConsumed *bool
 }
@@ -29,7 +30,7 @@ type EmailTokenFilter struct {
 type Store interface {
 	BeginTx(ctx context.Context) (Tx, error)
 
-	FindUsers(ctx context.Context, filter *UserFilter) ([]User, error)
+	FindUsers(ctx context.Context, filter UserFilter) ([]User, error)
 }
 
 // Tx is a transaction. If an error occurs on any of the Create/Update/Find methods,
@@ -39,11 +40,11 @@ type Tx interface {
 	Commit() error
 	Rollback() error
 
-	CreateUser(u *User) error
-	UpdateUser(u *User) error
-	FindUsers(filter *UserFilter) ([]User, error)
+	CreateUser(u User) error
+	UpdateUser(u User) error
+	FindUsers(filter UserFilter) ([]User, error)
 
-	CreateEmailToken(t *EmailToken) error
-	UpdateEmailToken(t *EmailToken) error
-	FindEmailTokens(filter *EmailTokenFilter) ([]EmailToken, error)
+	CreateEmailToken(t EmailToken) error
+	UpdateEmailToken(t EmailToken) error
+	FindEmailTokens(filter EmailTokenFilter) ([]EmailToken, error)
 }

--- a/internal/auth/user.go
+++ b/internal/auth/user.go
@@ -5,11 +5,13 @@ import (
 
 	"github.com/willemschots/househunt/internal/email"
 	"github.com/willemschots/househunt/internal/krypto"
+
+	"github.com/google/uuid"
 )
 
 // User contains the data for a user.
 type User struct {
-	ID           int
+	ID           uuid.UUID
 	Email        email.Address
 	PasswordHash krypto.Argon2Hash
 	IsActive     bool

--- a/migrations/0001_users_and_email_tokens.sql
+++ b/migrations/0001_users_and_email_tokens.sql
@@ -1,5 +1,5 @@
 CREATE TABLE users(
-    id                INTEGER PRIMARY KEY,
+    id                TEXT PRIMARY KEY,
     email_encrypted   TEXT NOT NULL,
     email_blind_index TEXT NOT NULL UNIQUE,
     password_hash     TEXT NOT NULL,
@@ -9,9 +9,9 @@ CREATE TABLE users(
 );
 
 CREATE TABLE email_tokens (
-    id              INTEGER PRIMARY KEY,
+    id              TEXT PRIMARY KEY,
     token_hash      TEXT NOT NULL,
-    user_id         INTEGER NOT NULL,
+    user_id         TEXT NOT NULL,
     email_encrypted TEXT NOT NULL,
     purpose         TEXT NOT NULL,
     created_at      TIMESTAMP NOT NULL,

--- a/migrations/docs/schema.gen.sql
+++ b/migrations/docs/schema.gen.sql
@@ -5,7 +5,7 @@ CREATE TABLE migrations (
 	revision_timestamp TIMESTAMP NOT NULL
 );
 CREATE TABLE users(
-    id                INTEGER PRIMARY KEY,
+    id                TEXT PRIMARY KEY,
     email_encrypted   TEXT NOT NULL,
     email_blind_index TEXT NOT NULL UNIQUE,
     password_hash     TEXT NOT NULL,
@@ -14,9 +14,9 @@ CREATE TABLE users(
     updated_at        TIMESTAMP NOT NULL
 );
 CREATE TABLE email_tokens (
-    id              INTEGER PRIMARY KEY,
+    id              TEXT PRIMARY KEY,
     token_hash      TEXT NOT NULL,
-    user_id         INTEGER NOT NULL,
+    user_id         TEXT NOT NULL,
     email_encrypted TEXT NOT NULL,
     purpose         TEXT NOT NULL,
     created_at      TIMESTAMP NOT NULL,


### PR DESCRIPTION
This PR changes the numeric IDs of `auth.User` and `auth.EmailToken` to use UUIDs instead.

### Why?

To prevent information leakage on the number of user accounts in the system. While there are [other options](https://czep.net/21/obfuscate.html), using UUIDs seems to be the most straightforward way IMO.

### Won't this be a performance issue?

I expect performance to be slightly worse since we're storing more data, but I'm not worried just yet. I'd rather focus on building the app and deal with bottlenecks when we encounter them.