### PR TITLE
4: Configure and wire up dependencies

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,7 @@
+# Set up the desired user and group ID for the container. Find this out by running `id` in the terminal.
+UID=<your user id here>
+GID=<your group id here>
+# CRYPTO_KEYS: Comma separated list of 32 byte keys used for encryption. Keys should be 64-characters and hex encoded.
+CRYPTO_KEYS=<your crypto keys here>
+# DB_BLIND_INDEX_SALT: 32 byte salt used for blind indexing. Salt should be 64-characters and hex encoded.
+DB_BLIND_INDEX_SALT=<your blind index salt here>

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.localdev
+.env

--- a/README.md
+++ b/README.md
@@ -29,3 +29,16 @@ You can see househunt in action at [examplego.com](https://examplego.com), this 
 ## Build in public
 
 Househunt is being build in public by [Willem Schots](https://www.willem.dev/), you can follow along [on Twitter](https://www.x.com/willemschots). 
+
+## Running househunt locally
+
+The recommended way to run the project locally is using docker compose, this will ease management of env variable based settings.
+
+1. Create a directory for storing the local data in the project root directory:
+```sh
+mkdir .localdev
+```
+2. Configure `.env` file based on the data in `.env.sample`.
+3. Run `docker compose up`. This will build the app and run it. You should see the database migrations being triggered and the HTTP server starting up.
+4. Navigate to `http://localhost:8888` to see househunt in action.
+

--- a/cmd/server/config_test.go
+++ b/cmd/server/config_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -15,7 +16,7 @@ func TestConfigFromEnv(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		if want != got {
+		if !reflect.DeepEqual(got, want) {
 			t.Errorf("got\n%+v\nwant\n%+v", got, want)
 		}
 	})
@@ -40,6 +41,12 @@ func TestConfigFromEnv(t *testing.T) {
 		"ok, non-default HTTP_SHUTDOWN_TIMEOUT": {
 			key: "HTTP_SHUTDOWN_TIMEOUT", val: "404ms", mf: func(c *config) { c.http.shutdownTimeout = 404 * time.Millisecond },
 		},
+		"ok, non-default DB_FILENAME": {
+			key: "DB_FILENAME", val: "test.db", mf: func(c *config) { c.db.file = "test.db" },
+		},
+		"ok, non-default DB_MIGRATE": {
+			key: "DB_MIGRATE", val: "false", mf: func(c *config) { c.db.migrate = false },
+		},
 	}
 
 	for name, tc := range valid {
@@ -54,7 +61,7 @@ func TestConfigFromEnv(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			if want != got {
+			if !reflect.DeepEqual(got, want) {
 				t.Errorf("got\n%+v\nwant\n%+v", got, want)
 			}
 		})
@@ -68,6 +75,8 @@ func TestConfigFromEnv(t *testing.T) {
 		"fail, negative HTTP_WRITE_TIMEOUT":    {"HTTP_WRITE_TIMEOUT", "-1ms"},
 		"fail, negative HTTP_IDLE_TIMEOUT":     {"HTTP_IDLE_TIMEOUT", "-1ms"},
 		"fail, negative HTTP_SHUTDOWN_TIMEOUT": {"HTTP_SHUTDOWN_TIMEOUT", "-1ms"},
+		"fail, empty DB_FILENAME":              {"DB_FILENAME", ""},
+		"fail, invalid DB_MIGRATE":             {"DB_MIGRATE", "no!"},
 	}
 
 	for name, tc := range invalid {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/willemschots/househunt/internal"
 	"github.com/willemschots/househunt/internal/db"
 	"github.com/willemschots/househunt/internal/db/migrate"
+	"github.com/willemschots/househunt/internal/krypto"
 	"github.com/willemschots/househunt/internal/web"
 	"github.com/willemschots/househunt/internal/web/view"
 	"github.com/willemschots/househunt/migrations"
@@ -80,6 +81,15 @@ func run(ctx context.Context, w io.Writer) int {
 			}
 		}
 	}
+
+	// Create encryptor.
+	_, err = krypto.NewEncryptor(cfg.crypto.keys)
+	if err != nil {
+		logger.Error("failed to create encryptor", "error", err)
+		return 1
+	}
+
+	// TODO: Create authentication store and service.
 
 	viewRenderer := view.NewFSRenderer(assets.TemplateFS)
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,17 +2,24 @@ package main
 
 import (
 	"context"
+	"database/sql"
+	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/willemschots/househunt/assets"
 	"github.com/willemschots/househunt/internal"
+	"github.com/willemschots/househunt/internal/db"
+	"github.com/willemschots/househunt/internal/db/migrate"
 	"github.com/willemschots/househunt/internal/web"
 	"github.com/willemschots/househunt/internal/web/view"
+	"github.com/willemschots/househunt/migrations"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -25,11 +32,53 @@ func main() {
 
 func run(ctx context.Context, w io.Writer) int {
 	logger := slog.New(slog.NewTextHandler(w, nil))
+	logger = logger.With("revision", internal.BuildRevision, "revision_time", internal.BuildRevisionTime)
 
 	cfg, err := configFromEnv()
 	if err != nil {
 		logger.Error("failed to get config from environment", "error", err)
 		return 1
+	}
+
+	// Connect to the database.
+	dbh, err := connectDB(cfg)
+	if err != nil {
+		logger.Error("failed to connect to database", "error", err)
+		return 1
+	}
+
+	defer func() {
+		err := dbh.close()
+		if err != nil {
+			logger.Error("failed to close database handles", "error", err)
+			return
+		}
+	}()
+
+	// Run the migrations if desired.
+	if cfg.db.migrate {
+		ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
+		defer cancel()
+
+		logger.Info("attempting to migrate database")
+
+		migrations, err := migrate.RunFS(ctx, dbh.write, migrations.FS, migrate.Metadata{
+			Revision:          internal.BuildRevision,
+			RevisionTimestamp: internal.BuildRevisionTime,
+		})
+
+		if err != nil {
+			logger.Error("failed to run migrations", "error", err)
+			return 1
+		}
+
+		if len(migrations) == 0 {
+			logger.Info("no migrations ran")
+		} else {
+			for _, m := range migrations {
+				logger.Info("migration ran", "name", m.Filename, "sequence", m.Sequence)
+			}
+		}
 	}
 
 	viewRenderer := view.NewFSRenderer(assets.TemplateFS)
@@ -49,12 +98,7 @@ func run(ctx context.Context, w io.Writer) int {
 	g, gCtx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
-		logger.Info("starting http server",
-			"addr", cfg.http.addr,
-			"buildRevision", internal.BuildRevision,
-			"buildRevisionTime", internal.BuildRevisionTime,
-			"buildLocalModified", internal.BuildLocalModified,
-		)
+		logger.Info("starting http server", "addr", cfg.http.addr)
 		// ListenAndServe always returns a non-nil error,
 		// g will cancel gCtx when an error is returned, so
 		// this will also stop the other goroutine.
@@ -80,4 +124,70 @@ func run(ctx context.Context, w io.Writer) int {
 	logger.Info("http server stopped successfully")
 
 	return 0
+}
+
+type dbHandles struct {
+	write *sql.DB
+	read  *sql.DB
+}
+
+// connectDB connects to the database and returns the write and read handles.
+func connectDB(cfg config) (*dbHandles, error) {
+	writeDB, err := db.OpenSQLite(cfg.db.file, true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open database write handle: %w", err)
+	}
+
+	readDB, err := db.OpenSQLite(cfg.db.file, false)
+	if err != nil {
+		closeErr := writeDB.Close()
+		if closeErr != nil {
+			err = errors.Join(err, closeErr)
+		}
+		return nil, fmt.Errorf("failed to open database read handle: %w", err)
+	}
+
+	handles := &dbHandles{write: writeDB, read: readDB}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err = handles.ping(ctx)
+	if err != nil {
+		closeErr := handles.close()
+		if closeErr != nil {
+			err = errors.Join(err, closeErr)
+		}
+		return nil, fmt.Errorf("failed to ping: %w", err)
+	}
+
+	return handles, nil
+}
+
+func (h *dbHandles) ping(ctx context.Context) error {
+	err := h.write.PingContext(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to ping database write handle: %w", err)
+	}
+
+	err = h.read.PingContext(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to ping database read handle: %w", err)
+	}
+
+	return nil
+}
+
+func (h *dbHandles) close() error {
+	err := h.write.Close()
+	if err != nil {
+		return fmt.Errorf("failed to close database write handle: %w", err)
+	}
+
+	err = h.read.Close()
+	if err != nil {
+		return fmt.Errorf("failed to close database read handle: %w", err)
+	}
+
+	return nil
 }

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -3,7 +3,10 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -21,7 +24,7 @@ const (
 )
 
 func Test_Run(t *testing.T) {
-	t.Run("ok, says it started then stopped http server", func(t *testing.T) {
+	t.Run("ok, says it started then stopped http server", appTest(func(t *testing.T) {
 		out := newBuffer()
 
 		ctx := cancelOnceServed(t, publicURL)
@@ -37,9 +40,44 @@ func Test_Run(t *testing.T) {
 			"stopping http server",
 			"http server stopped successfully",
 		)
-	})
+	}))
 
-	t.Run("fail, invalid environment", func(t *testing.T) {
+	t.Run("ok, says it ran migrations", appTest(func(t *testing.T) {
+		out := newBuffer()
+
+		ctx := cancelOnceServed(t, publicURL)
+
+		got := run(ctx, out)
+		want := 0
+		if got != want {
+			t.Fatalf("got exit code %d, want %d. logs:\n%s", got, want, out.String())
+		}
+
+		assertLog(t, out.String(),
+			"attempting to migrate database",
+			"migration ran",
+		)
+	}))
+
+	t.Run("ok, did not say it ran migrations when DB_MIGRATE=false", appTest(func(t *testing.T) {
+		envForTest(t, "DB_MIGRATE", "false")
+
+		out := newBuffer()
+
+		ctx := cancelOnceServed(t, publicURL)
+
+		got := run(ctx, out)
+		want := 0
+		if got != want {
+			t.Fatalf("got exit code %d, want %d. logs:\n%s", got, want, out.String())
+		}
+
+		if strings.Contains(out.String(), "attempting to migrate database") {
+			t.Errorf("expected not to run migrations, but did")
+		}
+	}))
+
+	t.Run("fail, invalid environment", appTest(func(t *testing.T) {
 		envForTest(t, "HTTP_READ_TIMEOUT", "-1ms")
 
 		out := newBuffer()
@@ -55,7 +93,7 @@ func Test_Run(t *testing.T) {
 		}
 
 		assertLog(t, out.String(), "failed to get config from environment")
-	})
+	}))
 }
 
 // safeBuffer is a buffer that is safe for concurrent use.
@@ -149,5 +187,33 @@ func waitForStatusOK(ctx context.Context, url string) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		}
+	}
+}
+
+func appTest(testFunc func(t *testing.T)) func(t *testing.T) {
+	testDBFile := "househunt-unit-test.db"
+
+	return func(t *testing.T) {
+		t.Helper()
+
+		envForTest(t, "DB_FILENAME", testDBFile)
+
+		t.Cleanup(func() {
+			// remove database files.
+			files := []string{
+				testDBFile,
+				fmt.Sprintf("%s-shm", testDBFile),
+				fmt.Sprintf("%s-wal", testDBFile),
+			}
+
+			for _, file := range files {
+				err := os.Remove(file)
+				if err != nil && !errors.Is(err, os.ErrNotExist) {
+					t.Fatalf("failed to remove file %s: %v", file, err)
+				}
+			}
+		})
+
+		testFunc(t)
 	}
 }

--- a/cmd/server/user_stories_test.go
+++ b/cmd/server/user_stories_test.go
@@ -12,7 +12,7 @@ import (
 // Test_UserStories tests the user stories of the application.
 // These are end-to-end tests and won't check the nitty-gritty details or edge cases.
 func Test_UserStories(t *testing.T) {
-	t.Run("as an unauthenticated agent, I want to", appTest(func(t *testing.T) {
+	t.Run("as an unauthenticated agent, I want to", testEnv(func(t *testing.T) {
 		runAppForTest(t)
 
 		t.Run("view the user registration form", func(t *testing.T) {

--- a/cmd/server/user_stories_test.go
+++ b/cmd/server/user_stories_test.go
@@ -12,7 +12,7 @@ import (
 // Test_UserStories tests the user stories of the application.
 // These are end-to-end tests and won't check the nitty-gritty details or edge cases.
 func Test_UserStories(t *testing.T) {
-	t.Run("as an unauthenticated agent, I want to", func(t *testing.T) {
+	t.Run("as an unauthenticated agent, I want to", appTest(func(t *testing.T) {
 		runAppForTest(t)
 
 		t.Run("view the user registration form", func(t *testing.T) {
@@ -37,7 +37,7 @@ func Test_UserStories(t *testing.T) {
 		//
 		//t.Run("login to my account", func(t *testing.T) {
 		//})
-	})
+	}))
 }
 
 // runAppForTest runs the app while the test is running.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.9"
+services:
+  househunt:
+    build: .
+     # Run container as the current user making it easier to manage files created by the container.
+    user: "${UID}:${GID}"
+    environment:
+    - "CRYPTO_KEYS=${CRYPTO_KEYS}"
+    - "DB_FILENAME=./data/househunt.db"
+    - "DB_BLIND_INDEX_SALT=${DB_BLIND_INDEX_SALT}"
+    volumes:
+    - ./.localdev:/data
+    ports:
+    - "8888:8888"

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,10 @@ module github.com/willemschots/househunt
 go 1.22.0
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/mattn/go-sqlite3 v1.14.22
 	golang.org/x/crypto v0.21.0
 	golang.org/x/sync v0.6.0
 )
 
-require (
-	github.com/google/uuid v1.6.0 // indirect
-	golang.org/x/sys v0.18.0 // indirect
-)
+require golang.org/x/sys v0.18.0 // indirect

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -18,7 +18,7 @@ const (
 	readOptions  = "?mode=ro_&_foreign_keys=on&_journal_mode=wal&_busy_timeout=5000"
 )
 
-// OpenSQLite3 opens a pool of SQLite3 connections. Different settings
+// OpenSQLite opens a pool of SQLite connections. Different settings
 // are appropriate for reading and writing, so this function needs to know
 // what the sql.DB will be used for.
 //

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -4,6 +4,8 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+
+	"github.com/willemschots/househunt/internal/auth"
 )
 
 // ViewRenderer renders named views with the given data.
@@ -11,23 +13,30 @@ type ViewRenderer interface {
 	Render(w io.Writer, name string, data any) error
 }
 
-func NewServer(logger *slog.Logger, viewRenderer ViewRenderer) http.Handler {
+// ServerDeps are the dependencies for the server.
+type ServerDeps struct {
+	Logger       *slog.Logger
+	ViewRenderer ViewRenderer
+	AuthService  *auth.Service
+}
+
+func NewServer(s *ServerDeps) http.Handler {
 	mux := http.NewServeMux()
 
 	mux.Handle("GET /", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		err := viewRenderer.Render(w, "hello-world", "Hello World! (via a template)")
+		err := s.ViewRenderer.Render(w, "hello-world", "Hello World! (via a template)")
 		if err != nil {
-			logger.Error("error rendering view", "error", err)
+			s.Logger.Error("error rendering view", "error", err)
 		}
 	}))
 
 	mux.Handle("GET /register", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		logger.Info("register page requested")
+		s.Logger.Info("register page requested")
 		w.WriteHeader(http.StatusOK)
-		err := viewRenderer.Render(w, "register-user", nil)
+		err := s.ViewRenderer.Render(w, "register-user", nil)
 		if err != nil {
-			logger.Error("error rendering view", "error", err)
+			s.Logger.Error("error rendering view", "error", err)
 		}
 	}))
 


### PR DESCRIPTION
This PR does some relatively boring but necessary things: It configures and wires up all dependencies in the `main` package.

It also adds a way to specify required env variables, used for encryption keys in this PR.

One thing I like about this code is that we can just embed the `auth.ServiceConfig` inside our config struct and map to it using the same mechanism as for our other configuration.

---

This PR also adds a basic docker-compose setup for running Househunt locally. See the README for instructions :)