### PR TITLE
15: fix flash messages not getting cleared

### DIFF
--- a/internal/web/sessions/session.go
+++ b/internal/web/sessions/session.go
@@ -34,6 +34,10 @@ func (s *Session) AddFlash(flash any, vars ...string) {
 	s.base.AddFlash(flash, vars...)
 }
 
-func (s *Session) Flashes() []any {
-	return s.base.Flashes()
+func (s *Session) ConsumeFlashes() []any {
+	flashes := s.base.Flashes()
+	if len(flashes) > 0 {
+		s.needsSave = true
+	}
+	return flashes
 }

--- a/internal/web/view_data.go
+++ b/internal/web/view_data.go
@@ -38,7 +38,7 @@ func (s *Server) prepViewData(r *http.Request, w http.ResponseWriter, data any) 
 		CSRFToken:   csrf.Token(r),
 		IsLoggedIn:  loggedIn,
 		UserID:      userID,
-		Flashes:     sess.Flashes(),
+		Flashes:     sess.ConsumeFlashes(),
 		InputForm:   r.Form,
 		InputErrors: nil,
 		Data:        data,


### PR DESCRIPTION
This PR ensures that flash messages are consumed after they are shown.

As seen in [this file](https://github.com/willemschots/househunt/blob/f16fd06d47a947eb9d57dc636746fe33c19868b5/internal/web/server.go#L284), writing of HTML views is done in multiple steps:
1. View data is prepared.
2. A `preWrite` function is called, which will update the session data in the cookie header if necessary.
3. The actual HTML view is rendered to the `http.ResponseWriter`.

The issue occurs in step 1. The preparation of the view data only read the flash messages in the session, it did not flag the session to be saved again in `preWrite`.

This PR fixes this issue by creating a new method: `ConsumeFlashes`. This method will flag the session for saving if there are any flash messages available. 

Closes: https://trello.com/c/EoHsvuk5/15-fix-flash-messages